### PR TITLE
shade-plugin: try exclude signature files

### DIFF
--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -194,6 +194,16 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">


### PR DESCRIPTION
Fix for starter maven-shade-plugin: exclude manifest signature files