### PR TITLE
workaround for error: FA³ST Service not compilable with Java16+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
         <sonar.language>java</sonar.language>
         <sonar.organization>fraunhofer-iosb</sonar.organization>
         <spotless.version>2.22.8</spotless.version>
+        <system.stubs.jupiter.version>2.0.1</system.stubs.jupiter.version>
     </properties>
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,6 @@
         <sonar.language>java</sonar.language>
         <sonar.organization>fraunhofer-iosb</sonar.organization>
         <spotless.version>2.22.8</spotless.version>
-        <system.lambda.version>1.2.1</system.lambda.version>
     </properties>
     <dependencies>
         <dependency>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -158,6 +158,20 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.plugin.compiler.version}</version>
                 <configuration>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -67,10 +67,15 @@
             <version>${logback.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-lambda</artifactId>
-            <version>${system.lambda.version}</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -158,20 +158,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.2</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven.plugin.compiler.version}</version>
                 <configuration>

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -67,17 +67,6 @@
             <version>${logback.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-inline</artifactId>
-            <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>uk.org.webcompere</groupId>
-            <artifactId>system-stubs-jupiter</artifactId>
-            <version>2.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>${jsonpath.version}</version>
@@ -131,6 +120,17 @@
             <groupId>io.admin-shell.aas</groupId>
             <artifactId>validator</artifactId>
             <version>${aas.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <version>${system.stubs.jupiter.version}</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/starter/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/starter/AppTest.java
+++ b/starter/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/starter/AppTest.java
@@ -61,7 +61,7 @@ public class AppTest {
     }
 
 
-    private EnvironmentVariables  withEnv(String... variables) {
+    private EnvironmentVariables withEnv(String... variables) {
         Ensure.requireNonNull(variables, "variables must be non-null");
         Ensure.require(variables.length >= 2, "variables must contain at least one element");
         Ensure.require(variables.length % 2 == 0, "variables must contain an even number of elements");

--- a/starter/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/starter/AppTest.java
+++ b/starter/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/starter/AppTest.java
@@ -14,7 +14,6 @@
  */
 package de.fraunhofer.iosb.ilt.faaast.service.starter;
 
-import com.github.stefanbirkner.systemlambda.SystemLambda;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.HttpEndpoint;
 import de.fraunhofer.iosb.ilt.faaast.service.starter.util.ParameterConstants;
 import de.fraunhofer.iosb.ilt.faaast.service.util.Ensure;
@@ -31,6 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import picocli.CommandLine;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 
 
 public class AppTest {
@@ -50,7 +50,7 @@ public class AppTest {
     }
 
 
-    private SystemLambda.WithEnvironmentVariables withEnv(Map<String, String> variables) {
+    private EnvironmentVariables withEnv(Map<String, String> variables) {
         return withEnv(variables.entrySet().stream()
                 .map(x -> new String[] {
                         x.getKey(),
@@ -61,12 +61,12 @@ public class AppTest {
     }
 
 
-    private SystemLambda.WithEnvironmentVariables withEnv(String... variables) {
+    private EnvironmentVariables  withEnv(String... variables) {
         Ensure.requireNonNull(variables, "variables must be non-null");
         Ensure.require(variables.length >= 2, "variables must contain at least one element");
         Ensure.require(variables.length % 2 == 0, "variables must contain an even number of elements");
 
-        SystemLambda.WithEnvironmentVariables result = null;
+        EnvironmentVariables result = null;
         for (int i = 0; i < variables.length; i += 2) {
             String key = variables[i];
             if (!Objects.equals(App.ENV_CONFIG_FILE_PATH, key) && !Objects.equals(App.ENV_MODEL_FILE_PATH, key)) {
@@ -76,7 +76,7 @@ public class AppTest {
             }
             String value = variables[i + 1];
             result = result == null
-                    ? SystemLambda.withEnvironmentVariable(key, value)
+                    ? new EnvironmentVariables(key, value)
                     : result.and(key, value);
         }
         return result;


### PR DESCRIPTION
add maven-surefire-plugin with arguments to allow changing environment variables which is no longer allowed from JDK 16

(Caused problems with SystemLambda.WithEnvironmentVariables.execute() in AppTest.java)
Known Problem in com.github.stefanbirkner.systemlambda.SystemLambda: https://github.com/stefanbirkner/system-lambda/issues/23

