### PR TITLE
Bugfix - fix error in reference helper with setting proper key elements

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/util/ReferenceHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/util/ReferenceHelper.java
@@ -110,8 +110,8 @@ public class ReferenceHelper {
                 null
         };
         for (Key k: keys) {
-            if (env.getAssetAdministrationShells().stream().anyMatch(x -> x.getIdentification().getIdentifier().equalsIgnoreCase(k.getValue())
-                    || x.getIdShort().equalsIgnoreCase(k.getValue()))) {
+            if (env.getAssetAdministrationShells().stream().anyMatch(x -> (x.getIdentification().getIdentifier().equalsIgnoreCase(k.getValue())
+                    || x.getIdShort().equalsIgnoreCase(k.getValue())) && parent[0] == null)) {
                 k.setType(KeyElements.ASSET_ADMINISTRATION_SHELL);
                 continue;
             }
@@ -127,13 +127,13 @@ public class ReferenceHelper {
                 continue;
             }
 
-            if (env.getConceptDescriptions().stream().anyMatch(x -> x.getIdentification().getIdentifier().equalsIgnoreCase(k.getValue())
-                    || x.getIdShort().equalsIgnoreCase(k.getValue()))) {
+            if (env.getConceptDescriptions().stream().anyMatch(x -> (x.getIdentification().getIdentifier().equalsIgnoreCase(k.getValue())
+                    || x.getIdShort().equalsIgnoreCase(k.getValue())) && parent[0] == null)) {
                 k.setType(KeyElements.CONCEPT_DESCRIPTION);
                 continue;
             }
-            if (env.getAssets().stream().anyMatch(x -> x.getIdentification().getIdentifier().equalsIgnoreCase(k.getValue())
-                    || x.getIdShort().equalsIgnoreCase(k.getValue()))) {
+            if (env.getAssets().stream().anyMatch(x -> (x.getIdentification().getIdentifier().equalsIgnoreCase(k.getValue())
+                    || x.getIdShort().equalsIgnoreCase(k.getValue())) && parent[0] == null)) {
                 k.setType(KeyElements.ASSET);
                 continue;
             }
@@ -334,12 +334,38 @@ public class ReferenceHelper {
         List<Key> keyList = new ArrayList<>();
         keyList.add(new DefaultKey.Builder()
                 .idType(KeyType.IRI)
-                .type(null)
+                .type(KeyElements.ASSET_ADMINISTRATION_SHELL)
                 .value(aasIdentifier)
                 .build());
         keyList.add(new DefaultKey.Builder()
                 .idType(KeyType.IRI)
-                .type(null)
+                .type(KeyElements.SUBMODEL)
+                .value(submodelIdentifier)
+                .build());
+        Stream.of(submodelElementIdshorts).forEach(
+                x -> keyList.add(new DefaultKey.Builder()
+                        .idType(KeyType.ID_SHORT)
+                        .type(null)
+                        .value(x)
+                        .build()));
+        return new DefaultReference.Builder()
+                .keys(keyList)
+                .build();
+    }
+
+
+    /**
+     * Builds a reference identifying a submodel element.
+     *
+     * @param submodelIdentifier the submodel identifier
+     * @param submodelElementIdshorts the submodel element idShort path
+     * @return a reference to the submodel element
+     */
+    public static Reference buildReferenceToSubmodelElement(String submodelIdentifier, String... submodelElementIdshorts) {
+        List<Key> keyList = new ArrayList<>();
+        keyList.add(new DefaultKey.Builder()
+                .idType(KeyType.IRI)
+                .type(KeyElements.SUBMODEL)
                 .value(submodelIdentifier)
                 .build());
         Stream.of(submodelElementIdshorts).forEach(
@@ -365,12 +391,12 @@ public class ReferenceHelper {
         List<Key> keyList = new ArrayList<>();
         keyList.add(new DefaultKey.Builder()
                 .idType(KeyType.IRI)
-                .type(null)
+                .type(KeyElements.ASSET_ADMINISTRATION_SHELL)
                 .value(aasIdentifier)
                 .build());
         keyList.add(new DefaultKey.Builder()
                 .idType(KeyType.IRI)
-                .type(null)
+                .type(KeyElements.SUBMODEL)
                 .value(submodelIdentifier)
                 .build());
         return new DefaultReference.Builder()

--- a/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/persistence/AbstractInMemoryPersistenceBaseTest.java
+++ b/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/persistence/AbstractInMemoryPersistenceBaseTest.java
@@ -34,6 +34,7 @@ import de.fraunhofer.iosb.ilt.faaast.service.util.DeepCopyHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.util.ExtendHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.util.ReferenceHelper;
 import io.adminshell.aas.v3.dataformat.core.util.AasUtils;
+import io.adminshell.aas.v3.model.Asset;
 import io.adminshell.aas.v3.model.AssetAdministrationShell;
 import io.adminshell.aas.v3.model.AssetAdministrationShellEnvironment;
 import io.adminshell.aas.v3.model.Blob;
@@ -47,6 +48,9 @@ import io.adminshell.aas.v3.model.Reference;
 import io.adminshell.aas.v3.model.Submodel;
 import io.adminshell.aas.v3.model.SubmodelElement;
 import io.adminshell.aas.v3.model.SubmodelElementCollection;
+import io.adminshell.aas.v3.model.impl.DefaultAsset;
+import io.adminshell.aas.v3.model.impl.DefaultAssetAdministrationShell;
+import io.adminshell.aas.v3.model.impl.DefaultConceptDescription;
 import io.adminshell.aas.v3.model.impl.DefaultIdentifier;
 import io.adminshell.aas.v3.model.impl.DefaultKey;
 import io.adminshell.aas.v3.model.impl.DefaultReference;
@@ -103,6 +107,49 @@ public abstract class AbstractInMemoryPersistenceBaseTest {
                 assId,
                 submodelId,
                 submodelElementIdShort);
+        SubmodelElement expected = environment.getSubmodels().stream()
+                .filter(x -> x.getIdentification().getIdentifier().equalsIgnoreCase(submodelId))
+                .findFirst().get()
+                .getSubmodelElements().stream()
+                .filter(x -> x.getIdShort().equalsIgnoreCase(submodelElementIdShort))
+                .findFirst().get();
+        SubmodelElement actual = persistence.get(reference, QueryModifier.DEFAULT);
+        Assert.assertEquals(expected, actual);
+    }
+
+
+    @Test
+    public void getSubmodelElementWithSimilarIDShortTest() throws ResourceNotFoundException {
+        String submodelId = "http://acplt.org/Submodels/Assets/TestAsset/BillOfMaterial";
+        String submodelElementIdShort = "ExampleEntity2";
+        Reference reference = ReferenceHelper.buildReferenceToSubmodelElement(
+                submodelId,
+                submodelElementIdShort);
+        ConceptDescription conceptDescription = new DefaultConceptDescription.Builder()
+                .idShort(submodelElementIdShort)
+                .identification(new DefaultIdentifier.Builder()
+                        .idType(IdentifierType.IRI)
+                        .identifier("http://example.org/CD")
+                        .build())
+                .category("Entity")
+                .build();
+        Asset asset = new DefaultAsset.Builder()
+                .idShort(submodelElementIdShort)
+                .identification(new DefaultIdentifier.Builder()
+                        .idType(IdentifierType.IRI)
+                        .identifier("http://example.org/Asset")
+                        .build())
+                .build();
+        AssetAdministrationShell shell = new DefaultAssetAdministrationShell.Builder()
+                .idShort(submodelElementIdShort)
+                .identification(new DefaultIdentifier.Builder()
+                        .idType(IdentifierType.IRI)
+                        .identifier("http://example.org/Shell")
+                        .build())
+                .build();
+        persistence.put(shell);
+        persistence.put(asset);
+        persistence.put(conceptDescription);
         SubmodelElement expected = environment.getSubmodels().stream()
                 .filter(x -> x.getIdentification().getIdentifier().equalsIgnoreCase(submodelId))
                 .findFirst().get()

--- a/docs/source/changelog/changelog.md
+++ b/docs/source/changelog/changelog.md
@@ -1,13 +1,16 @@
 # Changelog
 
 ## Current development version (0.4.0-SNAPSHOT)
-**Bugfixes**
-*   Fixed error related to JSONPath expressions that could occure in asset connections when using certain JSONPath expressions
+
+**New Features**
+
 
 **Internal changes & bugfixes**
 *   Asset Connection
 	*   OPC UA
 		*   Fixed problem converting DateTime values
+*   Fixed error related to JSONPath expressions that could occure in asset connections when using certain JSONPath expressions
+*   Fix error in reference helper with setting proper type of key elements when an identifiable and a independant referable have the same idshort
 
 ## Release version 0.3.0
 


### PR DESCRIPTION
Following scenario causes an error when resolving the reference to a submodel element:

If an Identifiable has the same idShort as a SubmodelElement in another Identifiable, the resolving mechanism gets the wrong type of the key element of the reference. 