### PR TITLE
Resolves newly detected vulnerabilities of third party libraries

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,6 +43,11 @@
             <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
@@ -129,6 +134,10 @@
                 <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/owaspSuppressions.xml
+++ b/owaspSuppressions.xml
@@ -10,4 +10,58 @@
 		<packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-databind@.*$</packageUrl>
 		<cve>CVE-2022-42003</cve>
 	</suppress>
+	<!-- begin: false positive -->
+	<suppress>
+		<notes><![CDATA[file name: msgpack-core-0.9.3.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/org\.msgpack/msgpack\-core@.*$</packageUrl>
+		<cve>CVE-2022-41719</cve>
+	</suppress>
+	<!-- end: false positive -->
+	<!-- begin: only affects FTP acces which is not used in this project -->
+	<suppress>
+		<notes><![CDATA[file name: commons-compress-1.21.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<suppress>
+		<notes><![CDATA[file name: commons-compress-1.22.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-compress@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<suppress>
+		<notes><![CDATA[file name: commons-csv-1.9.0.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-csv@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<suppress>
+		<notes><![CDATA[file name: commons-io-2.11.0.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/commons\-io/commons\-io@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<suppress>
+		<notes><![CDATA[file name: commons-logging-1.2.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/commons\-logging/commons\-logging@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<suppress>
+		<notes><![CDATA[file name: commons-math3-3.6.1.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons\-math3@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<suppress>
+		<notes><![CDATA[file name: jcl-over-slf4j-1.7.36.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/org\.slf4j/jcl\-over\-slf4j@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<suppress>
+		<notes><![CDATA[file name: commons-cli-1.5.0.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/commons\-cli/commons\-cli@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<suppress>
+		<notes><![CDATA[file name: commons-codec-1.15.jar]]></notes>
+		<packageUrl regex="true">^pkg:maven/commons\-codec/commons\-codec@.*$</packageUrl>
+		<cve>CVE-2021-37533</cve>
+	</suppress>
+	<!-- end: only affects FTP acces which is not used in this project -->
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,7 @@
         <sonar.organization>fraunhofer-iosb</sonar.organization>
         <systemstubs.version>2.0.1</systemstubs.version>
         <wiremock.version>2.35.0</wiremock.version>
+        <woodstox.version>6.4.0</woodstox.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
- `CVE-2021-37533` was suppressed, because it is related to FTP functionality that is not used in FA³ST
- other vulnerabilities have been resolved by excluding & replacing vulnerable (transitive) library