### PR TITLE
Add Dockerfile to create Dockerimage with no root privileges

### DIFF
--- a/misc/docker/docker-compose.yml
+++ b/misc/docker/docker-compose.yml
@@ -3,12 +3,10 @@ services:
   FA3ST:
     image: fraunhoferiosb/faaast-service
     volumes:
-      - ../examples/demoAAS.json:/AASEnv.json
-      - ../examples/exampleConfiguration.json:/config.json
+      - ../examples/demoAAS.json:/app/AASEnv.json
+      - ../examples/exampleConfiguration.json:/app/config.json
     environment:
-      - faaast.model=AASEnv.json
-      - faaast.config=config.json
+      - faaast.model=/app/AASEnv.json
+      - faaast.config=/app/config.json
     ports:
       - 8080:8080
-    command: --no-modelValidation
-

--- a/misc/examples/exampleConfiguration.json
+++ b/misc/examples/exampleConfiguration.json
@@ -8,7 +8,7 @@
         }],
     "persistence": {
         "@class": "de.fraunhofer.iosb.ilt.faaast.service.persistence.memory.PersistenceInMemory",
-        "initialModel": "./misc/examples/demoAAS.json",
+        "initialModel": "/app/AASEnv.json",
         "decoupleEnvironment": true
     },
     "messageBus": {

--- a/starter/Dockerfile
+++ b/starter/Dockerfile
@@ -1,0 +1,18 @@
+#* ASCII text, with CRLF line terminators
+From eclipse-temurin:11-jre
+
+# Copy to images tomcat path
+COPY ./target/starter-*-SNAPSHOT.jar /app/starter.jar
+
+RUN addgroup --system --gid 1000 faaast \
+    && adduser --system --uid 1000 --gid 1000 --no-create-home faaast \
+    # Grant read only permissions on working directory /app
+    && chgrp -R 0 /app \
+    && chmod -R g=u /app \
+    && chmod -R ugo+r /app \    
+    # Grant read and write permissions on log directory /logs
+    && mkdir /app/logs \
+    && chmod -R ugo+rw /app/logs
+USER faaast
+WORKDIR /app
+ENTRYPOINT ["java", "-jar", "starter.jar"]   


### PR DESCRIPTION
Add Dockerfile to create Dockerimage with no root privileges.

Adjust docker-compose and exampleConfiguration to work with image.

Grant full read permission on working directory because as I understood it, OPC UA certificates can also be located somewhere else than in the standard folders if the corresponding flag is set.

Grant write permission on log Directory.

have not deleted jib plugin, because I am afraid that a CI pipeline may no longer work. But can still delete it later if wanted