### PR TITLE
Fix 405 instead of 400 on some malformed URLs

### DIFF
--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/exception/RequestMapperNotFoundException.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/exception/RequestMapperNotFoundException.java
@@ -15,24 +15,14 @@
 package de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception;
 
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpRequest;
-import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.request.mapper.AbstractRequestMapper;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 
 /**
- * Exception to indicate a given method is not allowed for the URL.
+ * Exception to indicate there is no mapper for a path.
  */
-public class MethodNotAllowedException extends InvalidRequestException {
+public class RequestMapperNotFoundException extends InvalidRequestException {
 
-    public MethodNotAllowedException(HttpRequest request, Set<AbstractRequestMapper> allowedMethodMappers) {
-        super(String.format("method '%s' not allowed for URL '%s' (allowed methods: %s)",
-                request.getMethod(),
-                request.getPath(),
-                allowedMethodMappers.stream()
-                        .map(x -> x.getMethod().name())
-                        .distinct()
-                        .sorted()
-                        .collect(Collectors.joining(", "))));
+    public RequestMapperNotFoundException(HttpRequest request) {
+        super(String.format("no matching request mapper found for URL '%s'", request.getPath()));
     }
 }

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/AbstractInvokeOperationRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/AbstractInvokeOperationRequestMapper.java
@@ -43,7 +43,7 @@ import java.util.Map;
 public abstract class AbstractInvokeOperationRequestMapper<T extends InvokeOperationRequest<U>, U extends Response> extends AbstractSubmodelInterfaceRequestMapper<T, U> {
 
     protected static final String SUBMODEL_ELEMENT_PATH = RegExHelper.uniqueGroupName();
-    protected static final String PATTERN = String.format("submodel-elements/(?<%s>.*)/invoke", SUBMODEL_ELEMENT_PATH);
+    protected static final String PATTERN = String.format("submodel-elements/%s/invoke", pathElement(SUBMODEL_ELEMENT_PATH));
 
     protected AbstractInvokeOperationRequestMapper(ServiceContext serviceContext) {
         super(serviceContext, HttpMethod.POST, PATTERN);

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/DeleteAssetAdministrationShellByIdRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/DeleteAssetAdministrationShellByIdRequestMapper.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class DeleteAssetAdministrationShellByIdRequestMapper extends AbstractRequestMapper {
 
     private static final String AAS_ID = RegExHelper.uniqueGroupName();
-    private static final String PATTERN = String.format("(?!.*/aas)shells/(?<%s>.*)", AAS_ID);
+    private static final String PATTERN = String.format("(?!.*/aas)shells/%s", pathElement(AAS_ID));
 
     public DeleteAssetAdministrationShellByIdRequestMapper(ServiceContext serviceContext) {
         super(serviceContext, HttpMethod.DELETE, PATTERN);

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/GetAssetAdministrationShellByIdRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/GetAssetAdministrationShellByIdRequestMapper.java
@@ -41,12 +41,6 @@ public class GetAssetAdministrationShellByIdRequestMapper
 
 
     @Override
-    public boolean matchesUrl(HttpRequest httpRequest) {
-        return super.matchesUrl(httpRequest) && httpRequest.getPathElements().size() == 2;
-    }
-
-
-    @Override
     public GetAssetAdministrationShellByIdRequest doParse(HttpRequest httpRequest, Map<String, String> urlParameters, OutputModifier outputModifier) {
         return GetAssetAdministrationShellByIdRequest.builder()
                 .id(IdentifierHelper.parseIdentifier(EncodingHelper.base64Decode(urlParameters.get(AAS_ID))))

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import de.fraunhofer.iosb.ilt.faaast.service.ServiceContext;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.SerializationException;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception.InvalidRequestException;
+import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception.RequestMapperNotFoundException;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpMethod;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpRequest;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.serialization.HttpJsonApiSerializer;
@@ -979,15 +980,11 @@ public class RequestMappingManagerTest {
     }
 
 
-    @Test
+    @Test(expected = RequestMapperNotFoundException.class)
     public void testInvalidSubURL() throws InvalidRequestException {
-        String path = "shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus";
-        InvalidRequestException exception = Assert.assertThrows(InvalidRequestException.class,
-                () -> mappingManager.map(HttpRequest.builder()
-                        .method(HttpMethod.GET)
-                        .path(path)
-                        .build()));
-        // We only want the base class here (400), not children like MethodNotAllowedException (405).
-        Assert.assertEquals(InvalidRequestException.class, exception.getClass());
+        mappingManager.map(HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus")
+                .build());
     }
 }

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
@@ -979,11 +979,15 @@ public class RequestMappingManagerTest {
     }
 
 
-    @Test(expected = InvalidRequestException.class)
+    @Test
     public void testInvalidSubURL() throws InvalidRequestException {
-        mappingManager.map(HttpRequest.builder()
-                .method(HttpMethod.GET)
-                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus")
-                .build());
+        String path = "shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus";
+        InvalidRequestException exception = Assert.assertThrows(InvalidRequestException.class,
+                () -> mappingManager.map(HttpRequest.builder()
+                        .method(HttpMethod.GET)
+                        .path(path)
+                        .build()));
+        // We only want the base class here (400), not children like MethodNotAllowedException (405).
+        Assert.assertEquals(InvalidRequestException.class, exception.getClass());
     }
 }


### PR DESCRIPTION
`http://localhost:8080/shells/<any base64 string>/test` returns status code 405 (method not allowed) with `DELETE` being reported as supposedly valid while it should return 400 (bad request (no request mapper found)). This is because the `DeleteAssetAdministrationShellByIdRequestMapper` allows `/` in the shell id of URLs it accepts because it does not utilize `pathElement`. This issue was also present on the `AbstractInvokeOperationRequestMapper`.

I have additionally cleaned up a tiny bit of redundant code that is slightly related to the core issue.

### Considerations
1. The mappers for getting, putting and deleting a shell share their regex (save for the capture group's id). Ideally they would share this via inheritance, however that is not possible due to their existing inheritance hierarchy. The same redundancy (although without the bug) is present on the get put and delete submodel mappers (and probably in a similar manner elsewhere). The only solution that I can see would be a helper class, either per set of classes that share a regex or for larger groups of regexes. However, this is not exactly clean and I'm not sure if there is a cleaner solution or if it ultimately just preferable to leave it as is.
2. Writing the regression test at first proved quite difficult as the only way to reliably test the originally incorrect behavior was to either explicitly compare the class of the thrown exception (which required a comment for explanation) or its message, neither of which are really clean. This - to me - seemed indicative of a flaw in the design in which a method threw an exception of both a child class as well as its base class, making it difficult to distinguish between the two outside of simple try-catching (and even then only implicitly via the ordering of the catch clauses). Therefore I have decided to refactor this aspect a bit. I hope that my proposed design is sufficient, it also encapsulates the generation of the exception messages into the respective classes.