### PR TITLE
Make checking for existance in handlers consistent

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/PutAssetAdministrationShellByIdRequestHandler.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/PutAssetAdministrationShellByIdRequestHandler.java
@@ -18,7 +18,7 @@ import de.fraunhofer.iosb.ilt.faaast.service.assetconnection.AssetConnectionMana
 import de.fraunhofer.iosb.ilt.faaast.service.exception.MessageBusException;
 import de.fraunhofer.iosb.ilt.faaast.service.exception.ResourceNotFoundException;
 import de.fraunhofer.iosb.ilt.faaast.service.messagebus.MessageBus;
-import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.OutputModifier;
+import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.QueryModifier;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.response.PutAssetAdministrationShellByIdResponse;
 import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.event.change.ElementUpdateEventMessage;
 import de.fraunhofer.iosb.ilt.faaast.service.model.request.PutAssetAdministrationShellByIdRequest;
@@ -41,8 +41,9 @@ public class PutAssetAdministrationShellByIdRequestHandler extends AbstractReque
 
     @Override
     public PutAssetAdministrationShellByIdResponse process(PutAssetAdministrationShellByIdRequest request) throws ResourceNotFoundException, MessageBusException {
-        AssetAdministrationShell shell = (AssetAdministrationShell) persistence.get(request.getAas().getIdentification(), new OutputModifier());
-        shell = (AssetAdministrationShell) persistence.put(request.getAas());
+        //check if resource does exist
+        persistence.get(request.getAas().getIdentification(), QueryModifier.DEFAULT);
+        AssetAdministrationShell shell = (AssetAdministrationShell) persistence.put(request.getAas());
         messageBus.publish(ElementUpdateEventMessage.builder()
                 .element(shell)
                 .value(shell)

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/PutAssetAdministrationShellRequestHandler.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/PutAssetAdministrationShellRequestHandler.java
@@ -18,7 +18,7 @@ import de.fraunhofer.iosb.ilt.faaast.service.assetconnection.AssetConnectionMana
 import de.fraunhofer.iosb.ilt.faaast.service.exception.MessageBusException;
 import de.fraunhofer.iosb.ilt.faaast.service.exception.ResourceNotFoundException;
 import de.fraunhofer.iosb.ilt.faaast.service.messagebus.MessageBus;
-import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.OutputModifier;
+import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.QueryModifier;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.response.PutAssetAdministrationShellResponse;
 import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.event.change.ElementUpdateEventMessage;
 import de.fraunhofer.iosb.ilt.faaast.service.model.request.PutAssetAdministrationShellRequest;
@@ -41,8 +41,9 @@ public class PutAssetAdministrationShellRequestHandler extends AbstractRequestHa
 
     @Override
     public PutAssetAdministrationShellResponse process(PutAssetAdministrationShellRequest request) throws ResourceNotFoundException, MessageBusException {
-        AssetAdministrationShell shell = (AssetAdministrationShell) persistence.get(request.getAas().getIdentification(), new OutputModifier());
-        shell = (AssetAdministrationShell) persistence.put(request.getAas());
+        //check if resource does exist
+        persistence.get(request.getAas().getIdentification(), QueryModifier.DEFAULT);
+        AssetAdministrationShell shell = (AssetAdministrationShell) persistence.put(request.getAas());
         messageBus.publish(ElementUpdateEventMessage.builder()
                 .element(shell)
                 .value(shell)

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/PutConceptDescriptionByIdRequestHandler.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/PutConceptDescriptionByIdRequestHandler.java
@@ -18,7 +18,7 @@ import de.fraunhofer.iosb.ilt.faaast.service.assetconnection.AssetConnectionMana
 import de.fraunhofer.iosb.ilt.faaast.service.exception.MessageBusException;
 import de.fraunhofer.iosb.ilt.faaast.service.exception.ResourceNotFoundException;
 import de.fraunhofer.iosb.ilt.faaast.service.messagebus.MessageBus;
-import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.OutputModifier;
+import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.QueryModifier;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.response.PutConceptDescriptionByIdResponse;
 import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.event.change.ElementUpdateEventMessage;
 import de.fraunhofer.iosb.ilt.faaast.service.model.request.PutConceptDescriptionByIdRequest;
@@ -41,8 +41,9 @@ public class PutConceptDescriptionByIdRequestHandler extends AbstractRequestHand
 
     @Override
     public PutConceptDescriptionByIdResponse process(PutConceptDescriptionByIdRequest request) throws ResourceNotFoundException, MessageBusException {
-        ConceptDescription conceptDescription = (ConceptDescription) persistence.get(request.getConceptDescription().getIdentification(), new OutputModifier());
-        conceptDescription = (ConceptDescription) persistence.put(request.getConceptDescription());
+        //check if resource does exist
+        persistence.get(request.getConceptDescription().getIdentification(), QueryModifier.DEFAULT);
+        ConceptDescription conceptDescription = (ConceptDescription) persistence.put(request.getConceptDescription());
         messageBus.publish(ElementUpdateEventMessage.builder()
                 .element(conceptDescription)
                 .value(conceptDescription)


### PR DESCRIPTION
Just a tiny refactoring.
While some handlers were already using this setup others were simply assigning the value to the variable that is later used for the put operation which an IDE could flag as an unnecessary assignment, although it is actually used to assert that the object already exists. This is not at all clear from the previous code but this way it is.