### PR TITLE
Add Dockerfile to run FA³ST with non root permissions. Refactor related files

### DIFF
--- a/misc/docker/docker-compose.yml
+++ b/misc/docker/docker-compose.yml
@@ -1,12 +1,11 @@
 version: '3.4'
 services:
   FA3ST:
-    image: fraunhoferiosb/faaast-service
+    image: hansmees/faaast-no-root
     volumes:
-      - ../examples/demoAAS.json:/app/AASEnv.json
-      - ../examples/exampleConfiguration.json:/app/config.json
+      - ../examples/:/app/resources/
     environment:
-      - faaast.model=/app/AASEnv.json
-      - faaast.config=/app/config.json
+      - faaast.model=/app/resources/demoAAS.json
+      - faaast.config=/app/resources/exampleConfiguration.json
     ports:
       - 8080:8080

--- a/misc/docker/docker-compose.yml
+++ b/misc/docker/docker-compose.yml
@@ -3,12 +3,10 @@ services:
   FA3ST:
     image: fraunhoferiosb/faaast-service
     volumes:
-      - ../examples/demoAAS.json:/AASEnv.json
-      - ../examples/exampleConfiguration.json:/config.json
+      - ../examples/demoAAS.json:/app/AASEnv.json
+      - ../examples/exampleConfiguration.json:/app/config.json
     environment:
-      - faaast.model=AASEnv.json
-      - faaast.config=config.json
+      - faaast.model=/app/AASEnv.json
+      - faaast.config=/app/config.json
     ports:
       - 8080:8080
-    command: --no-modelValidation
-

--- a/misc/docker/docker-compose.yml
+++ b/misc/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   FA3ST:
-    image: hansmees/faaast-no-root
+    image: fraunhoferiosb/faaast-service
     volumes:
       - ../examples/:/app/resources/
     environment:

--- a/misc/examples/exampleConfiguration.json
+++ b/misc/examples/exampleConfiguration.json
@@ -8,7 +8,7 @@
         }],
     "persistence": {
         "@class": "de.fraunhofer.iosb.ilt.faaast.service.persistence.memory.PersistenceInMemory",
-        "initialModel": "/app/AASEnv.json",
+        "initialModel": "/app/resources/demoAAS.json",
         "decoupleEnvironment": true
     },
     "messageBus": {

--- a/misc/examples/exampleConfiguration.json
+++ b/misc/examples/exampleConfiguration.json
@@ -8,7 +8,7 @@
         }],
     "persistence": {
         "@class": "de.fraunhofer.iosb.ilt.faaast.service.persistence.memory.PersistenceInMemory",
-        "initialModel": "./misc/examples/demoAAS.json",
+        "initialModel": "/app/AASEnv.json",
         "decoupleEnvironment": true
     },
     "messageBus": {

--- a/starter/Dockerfile
+++ b/starter/Dockerfile
@@ -1,0 +1,18 @@
+#* ASCII text, with CRLF line terminators
+From eclipse-temurin:11-jre
+
+# Copy to images tomcat path
+COPY ./target/starter-*-SNAPSHOT.jar /app/starter.jar
+
+RUN addgroup --system --gid 1000 faaast \
+    && adduser --system --uid 1000 --gid 1000 --no-create-home faaast \
+    # Grant read only permissions on working directory /app
+    && chgrp -R 0 /app \
+    && chmod -R g=u /app \
+    && chmod -R ugo+r /app \    
+    # Grant read and write permissions on log directory /logs
+    && mkdir /app/logs \
+    && chmod -R ugo+rw /app/logs
+USER faaast
+WORKDIR /app
+ENTRYPOINT ["java", "-jar", "starter.jar"]   

--- a/starter/Dockerfile
+++ b/starter/Dockerfile
@@ -6,13 +6,14 @@ COPY ./target/starter-*-SNAPSHOT.jar /app/starter.jar
 
 RUN addgroup --system --gid 1000 faaast \
     && adduser --system --uid 1000 --gid 1000 --no-create-home faaast \
-    # Grant read only permissions on working directory /app
+    # restrict permissions on working directory /app
     && chgrp -R 0 /app \
     && chmod -R g=u /app \
-    && chmod -R ugo+r /app \    
-    # Grant read and write permissions on log directory /logs
-    && mkdir /app/logs \
-    && chmod -R ugo+rw /app/logs
+    # Create directories to which FA³ST needs permissions
+    && mkdir /app/resources /app/logs /app/PKI /app/USERS_PKI \
+    # Grant read and write permissions on created directories 
+    && chmod -R ugo+rw /app/resources /app/PKI /app/USERS_PKI /app/logs
+   
 USER faaast
 WORKDIR /app
 ENTRYPOINT ["java", "-jar", "starter.jar"]   


### PR DESCRIPTION
Create Dockerfile with working-directory /app -> no privilegies for FAAAST
Create additional Directories /app/resources /app/logs /app/PKI /app/USERS_PKI  -> read and write privilegies for FAAAST

PKI and /USERS_PKI for OPCUA

/resources for mounting other files that the user wants to use while running FAAAST (model or config)
for example: 
```
my current directory is FAAAST-Service/misc/examples

docker run --rm -v $(pwd)/:/app/resources/ faaast-no-root --endpoint OPCUA,HTTP -m /app/resources/demoAAS.json -c /app/resources/exampleConfiguration.json

(on windows you can use %cd% instead of $(pwd) )
```

refactored related files (Docker compose, example config)