### PR TITLE
Fix internal server error on nonstandard method

### DIFF
--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/RequestHandler.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/RequestHandler.java
@@ -89,11 +89,21 @@ public class RequestHandler extends AbstractHandler {
                 return;
             }
         }
+
+        HttpMethod method;
+        try {
+            method = HttpMethod.valueOf(request.getMethod());
+        }
+        catch (IllegalArgumentException e) {
+            HttpHelper.send(response, StatusCode.CLIENT_METHOD_NOT_ALLOWED, Result.error(String.format("Unknown method '%s'", request.getMethod())));
+            return;
+        }
+
         HttpRequest httpRequest = HttpRequest.builder()
                 .path(request.getRequestURI().replaceAll("/$", ""))
                 .query(request.getQueryString())
                 .body(reader.lines().collect(Collectors.joining(System.lineSeparator())))
-                .method(HttpMethod.valueOf(request.getMethod()))
+                .method(method)
                 .headers(Collections.list(request.getHeaderNames()).stream()
                         .collect(Collectors.toMap(
                                 x -> x,


### PR DESCRIPTION
Previously the exception would be uncaught and result in an internal server error, now the correct status code (405) is returned.

A regression test would probably be good but I'm unsure where and how to set up the likely necessary mocking.