### PR TITLE
[HTTP Endpoint] Return 400 instead of 405 on unspported URLs (valid URLs with additional path elements)

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/util/StreamHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/util/StreamHelper.java
@@ -12,17 +12,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception;
+package de.fraunhofer.iosb.ilt.faaast.service.util;
 
-import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpRequest;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 
 /**
- * Exception to indicate there is no mapper for a path.
+ * Utility class helping with streams.
  */
-public class RequestMapperNotFoundException extends InvalidRequestException {
+public class StreamHelper {
 
-    public RequestMapperNotFoundException(HttpRequest request) {
-        super(String.format("no matching request mapper found for URL '%s'", request.getPath()));
+    private StreamHelper() {}
+
+
+    /**
+     * Creates a stream of the given elements or an empty stream if agument is null or empty.
+     *
+     * @param <T> type of the elements
+     * @param values values to convert to stream
+     * @return a stream of the given elements
+     */
+    public static <T> Stream<T> toStream(T... values) {
+        return Arrays.asList(values).stream();
     }
 }

--- a/docs/source/changelog/changelog.md
+++ b/docs/source/changelog/changelog.md
@@ -6,6 +6,7 @@
 *   Improved exception handling in CLI - upon error starter application should now correctly terminate with error code 1
 *   OPC UA Endpoint
 	*   Additional parameters availabe in configuration
+*   Docker container now runs using a non-root user
 
 **Internal changes & bugfixes**
 *   HTTP Endpoint
@@ -13,8 +14,12 @@
 		*   /submodels/{submodelIdentifier}
 		*   /submodels/{submodelIdentifier}/submodel/submodel-elements/{idShortPath}
 		*   /shells/{aasIdentifier}/aas/submodels/{submodelIdentifier}/submodel/submodel-elements/{idShortPath}
+	*   Using not allowed HTTP methods not correctly returns `405 Method Not Allowed` instead of `500 Internal Server Error`
+	*   Unsupported URLS (valid URLs with additional path elements) now correctly return `400 Bad Request` instead of `405 Method not allowed`
 *   OPC UA Endpoint
 	*   Major code refactoring
+*   Miscellaneous
+	*   Now using dockerfile to build docker container instead of jib maven plugin
 
 ## Release version 0.4.0
 

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/RequestHandler.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/RequestHandler.java
@@ -138,7 +138,7 @@ public class RequestHandler extends AbstractHandler {
                             .map(x -> HttpMethod.valueOf(x.trim()))
                             .collect(Collectors.toSet())
                     : new HashSet<>();
-            Set<HttpMethod> allowedMethods = HttpHelper.findSupportedHTTPMethods(requestMappingManager, request.getRequestURI().replaceAll("/$", ""));
+            Set<HttpMethod> allowedMethods = requestMappingManager.getSupportedMethods(request.getRequestURI().replaceAll("/$", ""));
             allowedMethods.add(HttpMethod.OPTIONS);
             response.addHeader(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER,
                     allowedMethods.stream()

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/exception/MethodNotAllowedException.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/exception/MethodNotAllowedException.java
@@ -32,7 +32,7 @@ public class MethodNotAllowedException extends Exception {
                 request.getMethod(),
                 request.getPath(),
                 StreamHelper.toStream(allowedMethods)
-                        .map(x -> x.name())
+                        .map(Enum::name)
                         .distinct()
                         .sorted()
                         .collect(Collectors.joining(", "))));

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/exception/MethodNotAllowedException.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/exception/MethodNotAllowedException.java
@@ -14,25 +14,34 @@
  */
 package de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception;
 
+import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpMethod;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpRequest;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.request.mapper.AbstractRequestMapper;
-import java.util.Set;
+import de.fraunhofer.iosb.ilt.faaast.service.util.StreamHelper;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 
 /**
  * Exception to indicate a given method is not allowed for the URL.
  */
-public class MethodNotAllowedException extends InvalidRequestException {
+public class MethodNotAllowedException extends Exception {
 
-    public MethodNotAllowedException(HttpRequest request, Set<AbstractRequestMapper> allowedMethodMappers) {
+    public MethodNotAllowedException(HttpRequest request, HttpMethod... allowedMethods) {
         super(String.format("method '%s' not allowed for URL '%s' (allowed methods: %s)",
                 request.getMethod(),
                 request.getPath(),
-                allowedMethodMappers.stream()
-                        .map(x -> x.getMethod().name())
+                StreamHelper.toStream(allowedMethods)
+                        .map(x -> x.name())
                         .distinct()
                         .sorted()
                         .collect(Collectors.joining(", "))));
+    }
+
+
+    public MethodNotAllowedException(HttpRequest request, Collection<AbstractRequestMapper> allowedMethodMappers) {
+        this(request, allowedMethodMappers.stream()
+                .map(x -> x.getMethod())
+                .toArray(HttpMethod[]::new));
     }
 }

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/exception/RequestMapperNotFoundException.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/exception/RequestMapperNotFoundException.java
@@ -15,24 +15,14 @@
 package de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception;
 
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpRequest;
-import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.request.mapper.AbstractRequestMapper;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 
 /**
- * Exception to indicate a given method is not allowed for the URL.
+ * Exception to indicate there is no mapper for a path.
  */
-public class MethodNotAllowedException extends InvalidRequestException {
+public class RequestMapperNotFoundException extends InvalidRequestException {
 
-    public MethodNotAllowedException(HttpRequest request, Set<AbstractRequestMapper> allowedMethodMappers) {
-        super(String.format("method '%s' not allowed for URL '%s' (allowed methods: %s)",
-                request.getMethod(),
-                request.getPath(),
-                allowedMethodMappers.stream()
-                        .map(x -> x.getMethod().name())
-                        .distinct()
-                        .sorted()
-                        .collect(Collectors.joining(", "))));
+    public RequestMapperNotFoundException(HttpRequest request) {
+        super(String.format("no matching request mapper found for URL '%s'", request.getPath()));
     }
 }

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/model/HttpMethod.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/model/HttpMethod.java
@@ -21,6 +21,7 @@ public enum HttpMethod {
     GET,
     PUT,
     DELETE,
+    PATCH,
     POST,
     OPTIONS,
     HEAD,

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/AbstractInvokeOperationRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/AbstractInvokeOperationRequestMapper.java
@@ -43,7 +43,7 @@ import java.util.Map;
 public abstract class AbstractInvokeOperationRequestMapper<T extends InvokeOperationRequest<U>, U extends Response> extends AbstractSubmodelInterfaceRequestMapper<T, U> {
 
     protected static final String SUBMODEL_ELEMENT_PATH = RegExHelper.uniqueGroupName();
-    protected static final String PATTERN = String.format("submodel-elements/(?<%s>.*)/invoke", SUBMODEL_ELEMENT_PATH);
+    protected static final String PATTERN = String.format("submodel-elements/%s/invoke", pathElement(SUBMODEL_ELEMENT_PATH));
 
     protected AbstractInvokeOperationRequestMapper(ServiceContext serviceContext) {
         super(serviceContext, HttpMethod.POST, PATTERN);

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/AbstractRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/AbstractRequestMapper.java
@@ -31,7 +31,7 @@ import java.util.regex.Pattern;
 
 
 /**
- * Base class for mapping HTTP requests to protocl-agnostic requests.
+ * Base class for mapping HTTP requests to protocol-agnostic requests.
  */
 public abstract class AbstractRequestMapper {
 
@@ -75,7 +75,7 @@ public abstract class AbstractRequestMapper {
 
 
     /**
-     * Decides if a given HTTP request matches this concrete protocl-agnostic request.
+     * Decides if a given HTTP request matches this concrete protocol-agnostic request.
      *
      * @param httpRequest the HTTP request to check
      * @return true if matches, otherwise false
@@ -88,7 +88,7 @@ public abstract class AbstractRequestMapper {
 
 
     /**
-     * Decides if a given URL matches this concrete protocl-agnostic request.
+     * Decides if a given URL matches this concrete protocol-agnostic request.
      *
      * @param url the URL to check
      * @return true if matches, otherwise false

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/AbstractRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/AbstractRequestMapper.java
@@ -88,6 +88,21 @@ public abstract class AbstractRequestMapper {
 
 
     /**
+     * Decides if a given URL matches this concrete protocl-agnostic request.
+     *
+     * @param url the URL to check
+     * @return true if matches, otherwise false
+     * @throws IllegalArgumentException if url is null
+     */
+    public boolean matchesUrl(String url) {
+        Ensure.requireNonNull(url, "url must be non-null");
+        return matchesUrl(HttpRequest.builder()
+                .path(url)
+                .build());
+    }
+
+
+    /**
      * Converts the HTTP request to protocol-agnostic request.
      *
      * @param httpRequest the HTTP request to convert

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/DeleteAssetAdministrationShellByIdRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/DeleteAssetAdministrationShellByIdRequestMapper.java
@@ -31,7 +31,7 @@ import java.util.Map;
 public class DeleteAssetAdministrationShellByIdRequestMapper extends AbstractRequestMapper {
 
     private static final String AAS_ID = RegExHelper.uniqueGroupName();
-    private static final String PATTERN = String.format("(?!.*/aas)shells/(?<%s>.*)", AAS_ID);
+    private static final String PATTERN = String.format("(?!.*/aas)shells/%s", pathElement(AAS_ID));
 
     public DeleteAssetAdministrationShellByIdRequestMapper(ServiceContext serviceContext) {
         super(serviceContext, HttpMethod.DELETE, PATTERN);

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/GetAssetAdministrationShellByIdRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/GetAssetAdministrationShellByIdRequestMapper.java
@@ -41,12 +41,6 @@ public class GetAssetAdministrationShellByIdRequestMapper
 
 
     @Override
-    public boolean matchesUrl(HttpRequest httpRequest) {
-        return super.matchesUrl(httpRequest) && httpRequest.getPathElements().size() == 2;
-    }
-
-
-    @Override
     public GetAssetAdministrationShellByIdRequest doParse(HttpRequest httpRequest, Map<String, String> urlParameters, OutputModifier outputModifier) {
         return GetAssetAdministrationShellByIdRequest.builder()
                 .id(IdentifierHelper.parseIdentifier(EncodingHelper.base64Decode(urlParameters.get(AAS_ID))))

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/util/HttpHelper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/util/HttpHelper.java
@@ -16,10 +16,6 @@ package de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.util;
 
 import com.google.common.net.MediaType;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.SerializationException;
-import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception.InvalidRequestException;
-import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpMethod;
-import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpRequest;
-import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.request.RequestMappingManager;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.serialization.HttpJsonApiSerializer;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.MessageType;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.Result;
@@ -30,9 +26,7 @@ import java.io.IOException;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.jetty.http.HttpStatus;
@@ -80,33 +74,6 @@ public class HttpHelper {
             default:
                 throw new IllegalArgumentException(String.format("unsupported status code '%s'", statusCode.name()));
         }
-    }
-
-
-    /**
-     * Finds all methods of the url for which there is an implemented request mapper registered to the given mapping
-     * manager.
-     *
-     * @param mappingManager where the request mappers are registered
-     * @param url which should be checked
-     * @return all supported HTTP Methods of the given request
-     */
-    public static Set<HttpMethod> findSupportedHTTPMethods(RequestMappingManager mappingManager, String url) {
-        Set<HttpMethod> allowedMethods = new HashSet<>();
-        for (HttpMethod httpMethod: HttpMethod.values()) {
-            try {
-                HttpRequest httpRequest = HttpRequest.builder()
-                        .path(url)
-                        .method(httpMethod)
-                        .build();
-                mappingManager.findRequestMapper(httpRequest);
-                allowedMethods.add(httpMethod);
-            }
-            catch (InvalidRequestException ignored) {
-                //intentionally empty
-            }
-        }
-        return allowedMethods;
     }
 
 

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpointTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpointTest.java
@@ -317,6 +317,16 @@ public class HttpEndpointTest {
 
 
     @Test
+    public void testInvalidAASIdentifierAndAdditionalPathElement() throws Exception {
+        when(service.execute(any())).thenReturn(GetAssetAdministrationShellResponse.builder()
+                .statusCode(StatusCode.SUCCESS)
+                .build());
+        ContentResponse response = execute(HttpMethod.DELETE, "/shells/bogus/test");
+        Assert.assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
+    }
+
+
+    @Test
     public void testInvalidBase64Param() throws Exception {
         ContentResponse response = execute(HttpMethod.GET, "/concept-descriptions/InvalidBase64");
         Assert.assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 import de.fraunhofer.iosb.ilt.faaast.service.ServiceContext;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.SerializationException;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception.InvalidRequestException;
+import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception.RequestMapperNotFoundException;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpMethod;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpRequest;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.serialization.HttpJsonApiSerializer;
@@ -979,15 +980,11 @@ public class RequestMappingManagerTest {
     }
 
 
-    @Test
+    @Test(expected = RequestMapperNotFoundException.class)
     public void testInvalidSubURL() throws InvalidRequestException {
-        String path = "shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus";
-        InvalidRequestException exception = Assert.assertThrows(InvalidRequestException.class,
-                () -> mappingManager.map(HttpRequest.builder()
-                        .method(HttpMethod.GET)
-                        .path(path)
-                        .build()));
-        // We only want the base class here (400), not children like MethodNotAllowedException (405).
-        Assert.assertEquals(InvalidRequestException.class, exception.getClass());
+        mappingManager.map(HttpRequest.builder()
+                .method(HttpMethod.GET)
+                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus")
+                .build());
     }
 }

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
@@ -985,7 +985,7 @@ public class RequestMappingManagerTest {
         Assert.assertThrows(InvalidRequestException.class, () -> mappingManager.map(HttpRequest.builder()
                 .method(HttpMethod.GET)
                 .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus")
-                .build()));;
+                .build()));
     }
 
 

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 import de.fraunhofer.iosb.ilt.faaast.service.ServiceContext;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.SerializationException;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception.InvalidRequestException;
-import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception.RequestMapperNotFoundException;
+import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.exception.MethodNotAllowedException;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpMethod;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model.HttpRequest;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.serialization.HttpJsonApiSerializer;
@@ -135,7 +135,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testDeleteAASXPackageByIdRequest() throws InvalidRequestException {
+    public void testDeleteAASXPackageByIdRequest() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = DeleteAASXPackageByIdRequest.builder()
                 .packageId(AASX_PACKAGE_ID)
                 .build();
@@ -148,7 +148,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testDeleteAllAssetLinksByIdRequest() throws InvalidRequestException {
+    public void testDeleteAllAssetLinksByIdRequest() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = DeleteAllAssetLinksByIdRequest.builder()
                 .id(AAS.getIdentification())
                 .build();
@@ -161,7 +161,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testDeleteAssetAdministrationShellById() throws InvalidRequestException {
+    public void testDeleteAssetAdministrationShellById() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = DeleteAssetAdministrationShellByIdRequest.builder()
                 .id(AAS.getIdentification())
                 .build();
@@ -174,7 +174,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testDeleteConceptDescriptionById() throws InvalidRequestException {
+    public void testDeleteConceptDescriptionById() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = DeleteConceptDescriptionByIdRequest.builder()
                 .id(CONCEPT_DESCRIPTION.getIdentification())
                 .build();
@@ -187,7 +187,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testDeleteSubmodelById() throws InvalidRequestException {
+    public void testDeleteSubmodelById() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = DeleteSubmodelByIdRequest.builder()
                 .id(SUBMODEL.getIdentification())
                 .build();
@@ -200,7 +200,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testDeleteSubmodelElementByPath() throws SerializationException, InvalidRequestException {
+    public void testDeleteSubmodelElementByPath() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = DeleteSubmodelElementByPathRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(SUBMODEL_ELEMENT_REF))
@@ -215,7 +215,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testDeleteSubmodelReference() throws InvalidRequestException {
+    public void testDeleteSubmodelReference() throws InvalidRequestException, MethodNotAllowedException {
         Reference submodelRef = AasUtils.toReference(SUBMODEL);
         Request expected = DeleteSubmodelReferenceRequest.builder()
                 .id(AAS.getIdentification())
@@ -231,7 +231,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAASXByPackageIdRequest() throws InvalidRequestException {
+    public void testGetAASXByPackageIdRequest() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAASXByPackageIdRequest.builder()
                 .packageId(AASX_PACKAGE_ID)
                 .build();
@@ -244,7 +244,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllAASXPackageIdsRequest() throws InvalidRequestException {
+    public void testGetAllAASXPackageIdsRequest() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllAASXPackageIdsRequest.builder()
                 .aasId(AAS.getIdentification())
                 .build();
@@ -258,7 +258,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllAssetAdministrationShellIdsByAssetLinkRequest() throws SerializationException, InvalidRequestException {
+    public void testGetAllAssetAdministrationShellIdsByAssetLinkRequest() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllAssetAdministrationShellIdsByAssetLinkRequest.builder()
                 .assetIdentifierPairs(ASSET_IDENTIFIERS)
                 .build();
@@ -272,7 +272,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllAssetAdministrationShellsByAssetId() throws SerializationException, InvalidRequestException {
+    public void testGetAllAssetAdministrationShellsByAssetId() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         List<IdentifierKeyValuePair> assetIds = Arrays.asList(new DefaultIdentifierKeyValuePair.Builder()
                 .key(GLOBAL_ASSET_ID)
                 .value(AAS.getAssetInformation().getGlobalAssetId().getKeys().get(0).getValue())
@@ -292,7 +292,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllAssetAdministrationShellsByIdShort() throws InvalidRequestException {
+    public void testGetAllAssetAdministrationShellsByIdShort() throws InvalidRequestException, MethodNotAllowedException {
         String idShort = AAS.getIdShort();
         Request expected = GetAllAssetAdministrationShellsByIdShortRequest.builder()
                 .outputModifier(OutputModifier.DEFAULT)
@@ -308,7 +308,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllAssetAdministrationShellsRequest() throws InvalidRequestException {
+    public void testGetAllAssetAdministrationShellsRequest() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllAssetAdministrationShellsRequest.builder()
                 .outputModifier(OutputModifier.DEFAULT)
                 .build();
@@ -321,7 +321,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllAssetLinksByIdRequest() throws InvalidRequestException {
+    public void testGetAllAssetLinksByIdRequest() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllAssetLinksByIdRequest.builder()
                 .id(AAS.getIdentification())
                 .build();
@@ -334,7 +334,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllConceptDescriptions() throws InvalidRequestException {
+    public void testGetAllConceptDescriptions() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllConceptDescriptionsRequest.builder()
                 .build();
         Request actual = mappingManager.map(HttpRequest.builder()
@@ -346,7 +346,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllConceptDescriptionsByDataSpecificationReference() throws InvalidRequestException {
+    public void testGetAllConceptDescriptionsByDataSpecificationReference() throws InvalidRequestException, MethodNotAllowedException {
         Reference dataSpecificationRef = AasUtils.toReference(CONCEPT_DESCRIPTION);
         Request expected = GetAllConceptDescriptionsByDataSpecificationReferenceRequest.builder()
                 .dataSpecification(dataSpecificationRef)
@@ -361,7 +361,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllConceptDescriptionsByIdShort() throws InvalidRequestException {
+    public void testGetAllConceptDescriptionsByIdShort() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllConceptDescriptionsByIdShortRequest.builder()
                 .idShort(CONCEPT_DESCRIPTION.getIdShort())
                 .build();
@@ -375,7 +375,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllConceptDescriptionsByIsCaseOf() throws InvalidRequestException {
+    public void testGetAllConceptDescriptionsByIsCaseOf() throws InvalidRequestException, MethodNotAllowedException {
         Reference isCaseOf = CONCEPT_DESCRIPTION.getIsCaseOfs().get(0);
         Request expected = GetAllConceptDescriptionsByIsCaseOfRequest.builder()
                 .isCaseOf(isCaseOf)
@@ -390,7 +390,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllSubmodelElements() throws InvalidRequestException {
+    public void testGetAllSubmodelElements() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllSubmodelElementsRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .outputModifier(new OutputModifier.Builder()
@@ -407,7 +407,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllSubmodels() throws InvalidRequestException {
+    public void testGetAllSubmodels() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllSubmodelsRequest.builder()
                 .build();
         Request actual = mappingManager.map(HttpRequest.builder()
@@ -419,7 +419,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllSubmodelsByIdShort() throws InvalidRequestException {
+    public void testGetAllSubmodelsByIdShort() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllSubmodelsByIdShortRequest.builder()
                 .idShort(SUBMODEL.getIdShort())
                 .build();
@@ -433,7 +433,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAllSubmodelsBySemanticId() throws InvalidRequestException, SerializationException {
+    public void testGetAllSubmodelsBySemanticId() throws InvalidRequestException, MethodNotAllowedException, SerializationException {
         Request expected = GetAllSubmodelsBySemanticIdRequest.builder()
                 .semanticId(SUBMODEL.getSemanticId())
                 .build();
@@ -447,7 +447,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAssetAdministrationShell() throws InvalidRequestException {
+    public void testGetAssetAdministrationShell() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAssetAdministrationShellRequest.builder()
                 .id(AAS.getIdentification())
                 .outputModifier(new OutputModifier.Builder()
@@ -464,7 +464,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAssetAdministrationShellById() throws InvalidRequestException {
+    public void testGetAssetAdministrationShellById() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAssetAdministrationShellByIdRequest.builder()
                 .id(AAS.getIdentification())
                 .build();
@@ -477,7 +477,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetAssetInformationRequest() throws InvalidRequestException {
+    public void testGetAssetInformationRequest() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAssetInformationRequest.builder()
                 .id(AAS.getIdentification())
                 .build();
@@ -490,7 +490,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetConceptDescriptionById() throws InvalidRequestException {
+    public void testGetConceptDescriptionById() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetConceptDescriptionByIdRequest.builder()
                 .id(CONCEPT_DESCRIPTION.getIdentification())
                 .build();
@@ -503,7 +503,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetOperationAsyncResult() throws InvalidRequestException {
+    public void testGetOperationAsyncResult() throws InvalidRequestException, MethodNotAllowedException {
         final String handleId = UUID.randomUUID().toString();
         Request expected = GetOperationAsyncResultRequest.builder()
                 .handleId(handleId)
@@ -521,7 +521,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetSubmodel() throws InvalidRequestException {
+    public void testGetSubmodel() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetSubmodelRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .build();
@@ -534,7 +534,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetSubmodelByIdRequest() throws InvalidRequestException {
+    public void testGetSubmodelByIdRequest() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetSubmodelByIdRequest.builder()
                 .id(SUBMODEL.getIdentification())
                 .build();
@@ -547,7 +547,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testGetSubmodelElementByPath() throws InvalidRequestException {
+    public void testGetSubmodelElementByPath() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetSubmodelElementByPathRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(SUBMODEL_ELEMENT_REF))
@@ -581,7 +581,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testInvokeOperationAsyncContentNormal() throws SerializationException, InvalidRequestException {
+    public void testInvokeOperationAsyncContentNormal() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = InvokeOperationAsyncRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(OPERATION_REF))
@@ -603,7 +603,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testInvokeOperationAsyncContentValue() throws SerializationException, InvalidRequestException {
+    public void testInvokeOperationAsyncContentValue() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = InvokeOperationAsyncRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(OPERATION_REF))
@@ -625,7 +625,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testInvokeOperationSyncContentNormal() throws SerializationException, InvalidRequestException {
+    public void testInvokeOperationSyncContentNormal() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = InvokeOperationSyncRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(OPERATION_REF))
@@ -646,7 +646,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testInvokeOperationSyncContentValue() throws SerializationException, InvalidRequestException {
+    public void testInvokeOperationSyncContentValue() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = InvokeOperationSyncRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(OPERATION_REF))
@@ -668,7 +668,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testMappingGetAllSubmodelReferences() throws InvalidRequestException {
+    public void testMappingGetAllSubmodelReferences() throws InvalidRequestException, MethodNotAllowedException {
         Request expected = GetAllSubmodelReferencesRequest.builder()
                 .id(AAS.getIdentification())
                 .build();
@@ -682,7 +682,7 @@ public class RequestMappingManagerTest {
 
     @Test
     @Ignore("AASX not implemented yet")
-    public void testPostAASXPackageRequest() throws IOException, InvalidRequestException {
+    public void testPostAASXPackageRequest() throws IOException, InvalidRequestException, MethodNotAllowedException {
         Assert.fail("not implemented (multipart HTTP message");
         Request expected = PostAASXPackageRequest.builder()
                 .aasId(AAS.getIdentification())
@@ -703,7 +703,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPostAllAssetLinksByIdRequest() throws SerializationException, InvalidRequestException {
+    public void testPostAllAssetLinksByIdRequest() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PostAllAssetLinksByIdRequest.builder()
                 .id(AAS.getIdentification())
                 .assetLinks(ASSET_IDENTIFIERS)
@@ -718,7 +718,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPostAssetAdministrationShell() throws SerializationException, InvalidRequestException {
+    public void testPostAssetAdministrationShell() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PostAssetAdministrationShellRequest.builder()
                 .aas(AAS)
                 .build();
@@ -732,7 +732,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPostConceptDescription() throws SerializationException, InvalidRequestException {
+    public void testPostConceptDescription() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PostConceptDescriptionRequest.builder()
                 .conceptDescription(CONCEPT_DESCRIPTION)
                 .build();
@@ -746,7 +746,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPostSubmodel() throws SerializationException, InvalidRequestException {
+    public void testPostSubmodel() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PostSubmodelRequest.builder()
                 .submodel(SUBMODEL)
                 .build();
@@ -760,7 +760,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPostSubmodelElement() throws SerializationException, InvalidRequestException {
+    public void testPostSubmodelElement() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PostSubmodelElementRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .submodelElement(SUBMODEL_ELEMENT)
@@ -775,7 +775,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPostSubmodelElementByPath() throws SerializationException, InvalidRequestException {
+    public void testPostSubmodelElementByPath() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PostSubmodelElementByPathRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(SUBMODEL_ELEMENT_REF))
@@ -792,7 +792,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPostSubmodelReference() throws SerializationException, InvalidRequestException {
+    public void testPostSubmodelReference() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Reference submodelRef = AasUtils.toReference(SUBMODEL);
         Request expected = PostSubmodelReferenceRequest.builder()
                 .id(AAS.getIdentification())
@@ -809,7 +809,7 @@ public class RequestMappingManagerTest {
 
     @Test
     @Ignore("AASX not implemented yet")
-    public void testPutAASXPackageByIdRequest() throws IOException, InvalidRequestException {
+    public void testPutAASXPackageByIdRequest() throws IOException, InvalidRequestException, MethodNotAllowedException {
         Assert.fail("not implemented (requires multipart HTTP)");
         Request expected = GetAASXByPackageIdRequest.builder()
                 .packageId(AASX_PACKAGE_ID)
@@ -823,7 +823,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPutAssetAdministrationShell() throws SerializationException, InvalidRequestException {
+    public void testPutAssetAdministrationShell() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PutAssetAdministrationShellRequest.builder()
                 .id(AAS.getIdentification())
                 .aas(AAS)
@@ -838,7 +838,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPutAssetAdministrationShellById() throws SerializationException, InvalidRequestException {
+    public void testPutAssetAdministrationShellById() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PutAssetAdministrationShellByIdRequest.builder()
                 .id(AAS.getIdentification())
                 .aas(AAS)
@@ -853,7 +853,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPutAssetInformationRequest() throws SerializationException, InvalidRequestException {
+    public void testPutAssetInformationRequest() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PutAssetInformationRequest.builder()
                 .id(AAS.getIdentification())
                 .assetInformation(AAS.getAssetInformation())
@@ -868,7 +868,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPutConceptDescriptionById() throws SerializationException, InvalidRequestException {
+    public void testPutConceptDescriptionById() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PutConceptDescriptionByIdRequest.builder()
                 .id(CONCEPT_DESCRIPTION.getIdentification())
                 .conceptDescription(CONCEPT_DESCRIPTION)
@@ -883,7 +883,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPutSubmodel() throws SerializationException, InvalidRequestException {
+    public void testPutSubmodel() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PutSubmodelRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .submodel(SUBMODEL)
@@ -898,7 +898,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPutSubmodelById() throws SerializationException, InvalidRequestException {
+    public void testPutSubmodelById() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PutSubmodelByIdRequest.builder()
                 .id(SUBMODEL.getIdentification())
                 .submodel(SUBMODEL)
@@ -913,7 +913,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testPutSubmodelElementByPath() throws SerializationException, InvalidRequestException {
+    public void testPutSubmodelElementByPath() throws SerializationException, InvalidRequestException, MethodNotAllowedException {
         Request expected = PutSubmodelElementByPathRequest.builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(SUBMODEL_ELEMENT_REF))
@@ -930,7 +930,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testSetSubmodelElementValueByPathContentNormal() throws SerializationException, InvalidRequestException, Exception {
+    public void testSetSubmodelElementValueByPathContentNormal() throws Exception {
         SetSubmodelElementValueByPathRequest expected = SetSubmodelElementValueByPathRequest.<String> builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(SUBMODEL_ELEMENT_REF))
@@ -951,7 +951,7 @@ public class RequestMappingManagerTest {
 
 
     @Test
-    public void testSetSubmodelElementValueByPathContentValue() throws SerializationException, InvalidRequestException, Exception {
+    public void testSetSubmodelElementValueByPathContentValue() throws Exception {
         SetSubmodelElementValueByPathRequest expected = SetSubmodelElementValueByPathRequest.<String> builder()
                 .submodelId(SUBMODEL.getIdentification())
                 .path(ReferenceHelper.toKeys(SUBMODEL_ELEMENT_REF))
@@ -971,20 +971,29 @@ public class RequestMappingManagerTest {
     }
 
 
-    @Test(expected = InvalidRequestException.class)
-    public void testUnknownPath() throws InvalidRequestException {
-        mappingManager.map(HttpRequest.builder()
+    @Test
+    public void testUnknownPath() {
+        Assert.assertThrows(InvalidRequestException.class, () -> mappingManager.map(HttpRequest.builder()
                 .method(HttpMethod.GET)
                 .path("foo")
-                .build());
+                .build()));
     }
 
 
-    @Test(expected = RequestMapperNotFoundException.class)
-    public void testInvalidSubURL() throws InvalidRequestException {
-        mappingManager.map(HttpRequest.builder()
+    @Test
+    public void testInvalidSubURL() {
+        Assert.assertThrows(InvalidRequestException.class, () -> mappingManager.map(HttpRequest.builder()
                 .method(HttpMethod.GET)
                 .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus")
-                .build());
+                .build()));;
+    }
+
+
+    @Test
+    public void testUnsupportedOperation() {
+        Assert.assertThrows(MethodNotAllowedException.class, () -> mappingManager.map(HttpRequest.builder()
+                .method(HttpMethod.PATCH)
+                .path("shells")
+                .build()));;
     }
 }

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
@@ -994,6 +994,6 @@ public class RequestMappingManagerTest {
         Assert.assertThrows(MethodNotAllowedException.class, () -> mappingManager.map(HttpRequest.builder()
                 .method(HttpMethod.PATCH)
                 .path("shells")
-                .build()));;
+                .build()));
     }
 }

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
@@ -979,11 +979,15 @@ public class RequestMappingManagerTest {
     }
 
 
-    @Test(expected = InvalidRequestException.class)
+    @Test
     public void testInvalidSubURL() throws InvalidRequestException {
-        mappingManager.map(HttpRequest.builder()
-                .method(HttpMethod.GET)
-                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus")
-                .build());
+        String path = "shells/" + EncodingHelper.base64UrlEncode(AAS.getIdentification().getIdentifier()) + "/bogus";
+        InvalidRequestException exception = Assert.assertThrows(InvalidRequestException.class,
+                () -> mappingManager.map(HttpRequest.builder()
+                        .method(HttpMethod.GET)
+                        .path(path)
+                        .build()));
+        // We only want the base class here (400), not children like MethodNotAllowedException (405).
+        Assert.assertEquals(InvalidRequestException.class, exception.getClass());
     }
 }


### PR DESCRIPTION
This PR is based on and superseeds https://github.com/FraunhoferIOSB/FAAAST-Service/pull/333 by @Saalvage 

Additional comments

- `MethodNotAllowedException` is modelled as independent class rather than subclass of `InvalidRequestException` as it represents a different HTTP status code
- Additional tests added
- The issue of duplicate URL patterns in related request mapper classes is probably not the best solution, but refacotring is not straigthforward. As this is not a bug but rather refactoring it is not addressed in this PR.