### PR TITLE
Fix hyperlinks in docs

### DIFF
--- a/docs/source/about/about.md
+++ b/docs/source/about/about.md
@@ -31,4 +31,4 @@ Distributed under the Apache 2.0 License. See `LICENSE` for more information.
 
 Copyright (C) 2022 Fraunhofer Institut IOSB, Fraunhoferstr. 1, D 76131 Karlsruhe, Germany.
 
-You should have received a copy of the Apache 2.0 License along with this program. If not, see https://www.apache.org/licenses/LICENSE-2.0.html.
+You should have received a copy of the Apache 2.0 License along with this program. If not, see [https://www.apache.org/licenses/LICENSE-2.0.html](https://www.apache.org/licenses/LICENSE-2.0.html).

--- a/docs/source/examples/assetconnection-custom.md
+++ b/docs/source/examples/assetconnection-custom.md
@@ -1,5 +1,5 @@
 # Example: Custom Asset Connection
 
-You can find the full source code for this example at https://github.com/FraunhoferIOSB/FAAAST-Service/examples/assetcommectin-custom .
+You can find the full source code for this example [here](https://github.com/FraunhoferIOSB/FAAAST-Service/tree/main/examples/assetconnection-custom).
 
 This page will be updated with a detailed description in the future.


### PR DESCRIPTION
The docs provider seemingly requires all hyperlinks to be marked explicitly (and one of the links was wrong).