### PR TITLE
Improve `ExecutionExceptionHandler`

### DIFF
--- a/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/ExecutionExceptionHandler.java
+++ b/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/ExecutionExceptionHandler.java
@@ -26,7 +26,18 @@ public class ExecutionExceptionHandler implements IExecutionExceptionHandler {
 
     @Override
     public int handleExecutionException(Exception ex, CommandLine cmd, ParseResult parseResult) {
-        cmd.getErr().println(cmd.getColorScheme().errorText(ex.getMessage()));
+        Throwable thrown = ex;
+        int indent = 0;
+        while (thrown != null) {
+            String msg = thrown.getMessage();
+            String className = thrown.getClass().getSimpleName();
+            String info = msg != null
+                    ? String.format("%s (%s)", msg, className)
+                    : className;
+            cmd.getErr().println(cmd.getColorScheme().errorText("  ".repeat(indent) + info));
+            thrown = thrown.getCause();
+            indent++;
+        }
         return cmd.getExitCodeExceptionMapper() != null
                 ? cmd.getExitCodeExceptionMapper().getExitCode(ex)
                 : cmd.getCommandSpec().exitCodeOnExecutionException();


### PR DESCRIPTION
The current handler suffers from two issues:
- Providing very little info
- Throwing when the exception message is `null`

Nested exceptions are thrown elsewhere, but not utilized when displaying them to the user.

Examples:
- `IOExeption`s are wrapped into `InitializationException`s which results in nothing but `Error loading config file` being printed, making diagnosing issues with a config file pretty hard.
- Using `config-minimal.json` from `starter\src\test\resources` results in a `NullPointerException` (probably a bug as well) which doesn't have a message in turn causing a `NullPointerException` to be thrown from the print statement.

Design of printing could be reconsidered, currently it unwraps an exception like this:
```
Error loading config file (InitializationException)
  class 'de.fraunhofer.iosb.ilt.faaast.service.example.assetconnection.http.HttpAssetConnection' not found in classplath (through reference chain: de.fraunhofer.iosb.ilt.faaast.service.config.ServiceConfig["assetConnections"]->java.util.ArrayList[0]) (JsonMappingException)
    class 'de.fraunhofer.iosb.ilt.faaast.service.example.assetconnection.http.HttpAssetConnection' not found in classplath (IOException)
      de.fraunhofer.iosb.ilt.faaast.service.example.assetconnection.http.HttpAssetConnection (ClassNotFoundException)
```