### PR TITLE
Fix config override exception

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/persistence/PersistenceConfig.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/persistence/PersistenceConfig.java
@@ -14,6 +14,7 @@
  */
 package de.fraunhofer.iosb.ilt.faaast.service.persistence;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import de.fraunhofer.iosb.ilt.faaast.service.config.Config;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.DeserializationException;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.EnvironmentSerializationManager;
@@ -37,6 +38,7 @@ public abstract class PersistenceConfig<T extends Persistence> extends Config<T>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceConfig.class);
     protected File initialModelFile;
+    @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, defaultImpl = DefaultAssetAdministrationShellEnvironment.class)
     protected AssetAdministrationShellEnvironment initialModel;
 
     public File getInitialModelFile() {

--- a/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/App.java
+++ b/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/App.java
@@ -295,11 +295,11 @@ public class App implements Runnable {
         catch (IOException e) {
             throw new InitializationException("Error loading config file", e);
         }
-        withModel(config);
-        validateModelIfRequired(config);
         if (autoCompleteConfiguration) {
             ServiceConfigHelper.autoComplete(config);
         }
+        withModel(config);
+        validateModelIfRequired(config);
         try {
             ServiceConfigHelper.apply(config, endpoints.stream()
                     .map(LambdaExceptionHelper.rethrowFunction(

--- a/starter/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/starter/AppTest.java
+++ b/starter/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/starter/AppTest.java
@@ -114,8 +114,7 @@ public class AppTest {
                 .map(x -> String.format("%s=%s", x.getKey(), x.getValue()))
                 .toArray(String[]::new);
         Map<String, String> actual = withEnv(envProperties).execute(() -> {
-            // TODO: Fix test and use executeAssertSuccess here as well
-            new CommandLine(application).execute(args);
+            executeAssertSuccess(args);
             return application.getConfigOverrides();
         });
         Assert.assertEquals(expected, actual);

--- a/starter/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/starter/AppTest.java
+++ b/starter/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/starter/AppTest.java
@@ -94,6 +94,12 @@ public class AppTest {
     }
 
 
+    private void executeAssertSuccess(String... args) {
+        int ret = cmd.execute(args);
+        Assert.assertEquals(0, ret);
+    }
+
+
     @Test
     public void testGetConfigOverrides() throws Exception {
         Map<String, String> cliProperties = new HashMap<>();
@@ -108,6 +114,7 @@ public class AppTest {
                 .map(x -> String.format("%s=%s", x.getKey(), x.getValue()))
                 .toArray(String[]::new);
         Map<String, String> actual = withEnv(envProperties).execute(() -> {
+            // TODO: Fix test and use executeAssertSuccess here as well
             new CommandLine(application).execute(args);
             return application.getConfigOverrides();
         });
@@ -117,14 +124,14 @@ public class AppTest {
 
     @Test
     public void testConfigFileCLI() {
-        cmd.execute("-c", CONFIG);
+        executeAssertSuccess("-c", CONFIG);
         Assert.assertEquals(new File(CONFIG), application.configFile);
     }
 
 
     @Test
     public void testConfigFileCLIDefault() {
-        cmd.execute();
+        executeAssertSuccess();
         Assert.assertEquals(new File(App.CONFIG_FILENAME_DEFAULT), application.configFile);
     }
 
@@ -133,7 +140,7 @@ public class AppTest {
     public void testConfigFileENV() throws Exception {
         File actual = withEnv(App.ENV_CONFIG_FILE_PATH, CONFIG)
                 .execute(() -> {
-                    new CommandLine(application).execute();
+                    executeAssertSuccess();
                     return application.configFile;
                 });
         Assert.assertEquals(new File(CONFIG), actual);
@@ -142,7 +149,7 @@ public class AppTest {
 
     @Test
     public void testModelFileCLI() {
-        cmd.execute("-m", modelPath.toString());
+        executeAssertSuccess("-m", modelPath.toString());
         Assert.assertEquals(modelPath.toFile(), application.modelFile);
     }
 
@@ -151,7 +158,7 @@ public class AppTest {
     public void testModelFileENV() throws Exception {
         File actual = withEnv(App.ENV_MODEL_FILE_PATH, modelPath.toString())
                 .execute(() -> {
-                    new CommandLine(application).execute();
+                    executeAssertSuccess();
                     return application.modelFile;
                 });
         Assert.assertEquals(modelPath.toFile(), actual);
@@ -162,7 +169,7 @@ public class AppTest {
     public void testModelFilePrio() throws Exception {
         File actual = withEnv(App.ENV_MODEL_FILE_PATH, "env.json")
                 .execute(() -> {
-                    new CommandLine(application).execute("-m", modelPath.toString());
+                    executeAssertSuccess("-m", modelPath.toString());
                     return application.modelFile;
                 });
         Assert.assertEquals(modelPath.toFile(), actual);
@@ -171,42 +178,42 @@ public class AppTest {
 
     @Test
     public void testUseEmptyModelCLI() {
-        cmd.execute("--emptyModel");
+        executeAssertSuccess("--emptyModel");
         Assert.assertTrue(application.useEmptyModel);
     }
 
 
     @Test
     public void testUseEmptyModelCLIDefault() {
-        cmd.execute();
+        executeAssertSuccess();
         Assert.assertFalse(application.useEmptyModel);
     }
 
 
     @Test
     public void testAutoCompleteConfigurationCLI() {
-        cmd.execute("--no-autoCompleteConfig");
+        executeAssertSuccess("--no-autoCompleteConfig");
         Assert.assertFalse(application.autoCompleteConfiguration);
     }
 
 
     @Test
     public void testAutoCompleteConfigurationCLIDefault() {
-        cmd.execute();
+        executeAssertSuccess();
         Assert.assertTrue(application.autoCompleteConfiguration);
     }
 
 
     @Test
     public void testModelValidationCLI() {
-        cmd.execute("--no-modelValidation");
+        executeAssertSuccess("--no-modelValidation");
         Assert.assertFalse(application.validateModel);
     }
 
 
     @Test
     public void testModelValidationCLIDefault() {
-        cmd.execute("-m", modelPath.toString());
+        executeAssertSuccess("-m", modelPath.toString());
         Assert.assertTrue(application.validateModel);
     }
 
@@ -215,10 +222,10 @@ public class AppTest {
     public void testEndpointsCLI() {
         var expected = List.of(EndpointType.HTTP, EndpointType.OPCUA);
 
-        cmd.execute("--endpoint", "http", "--endpoint", "opcua");
+        executeAssertSuccess("--endpoint", "http", "--endpoint", "opcua");
         Assert.assertEquals(expected, application.endpoints);
 
-        cmd.execute("--endpoint", "http,opcua");
+        executeAssertSuccess("--endpoint", "http,opcua");
         Assert.assertEquals(expected, application.endpoints);
     }
 }


### PR DESCRIPTION
Draft as this builds on #386.

Config overrides are implemented in `ServiceConfigHelper::withProperties` by serializing the config, applying the overrides and then deserializing again. This was causing issues because the default `initialModel` is serializing to an empty JSON object, which in turn failed to deserialize at all since the static type is abstract.

It might be necessary to deal with the serializing of this field more properly. However, there appears to be only one subtype anyways (are others constructed / bound dynamically?) and with my limited knowledge I was not easily able to construct a failure case with the current approach.

Properly dealing with it would mean one of two things:
- Using `@JsonIgnore` on the property and setting the model after deserialization manually (under the assumptions that a: serialization of the `PersistenceConfig` is not required elsewhere and b: overrides are unable to affect the `initialModel`)
- Properly include the dynamic class in the serialization via `JsonTypeInfo.Id.CLASS`

If there is any reason to maintain current outward facing serialization behavior of `PersistenceConfig` it might be possible to configure the `mapper` in `ServiceConfigHelper` specifically to suit our needs since the config overrides are the only location it's used.