### PR TITLE
Hide server info in HTTP response headers

### DIFF
--- a/docs/source/changelog/changelog.md
+++ b/docs/source/changelog/changelog.md
@@ -5,6 +5,7 @@
 **Internal changes & bugfixes**
 *   HTTP Endpoint
 	*   Now correctly uses base64URL-encoding for all HTTP requests (instead of base64-encoding for some)
+    *   Configured http response header to hide the server information
 *   Asset Connection
 	*   OPC UA
 		*   Unit tests no longer create temp files in source folders
@@ -154,7 +155,7 @@
 
 *   Add builder classes for event messages & config classes
 
-*   Replace AASEnvironmentHelper with methods of EnvironmentSerialization 
+*   Replace AASEnvironmentHelper with methods of EnvironmentSerialization
 
 ## Release version 0.1.0
 

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpoint.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/HttpEndpoint.java
@@ -19,8 +19,7 @@ import de.fraunhofer.iosb.ilt.faaast.service.config.CoreConfig;
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.Endpoint;
 import de.fraunhofer.iosb.ilt.faaast.service.exception.EndpointException;
 import de.fraunhofer.iosb.ilt.faaast.service.util.Ensure;
-import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +61,8 @@ public class HttpEndpoint implements Endpoint<HttpEndpointConfig> {
         if (server != null && server.isStarted()) {
             return;
         }
-        server = new Server(config.getPort());
+        server = new Server();
+        configHttpResponseHeader();
         handler = new RequestHandler(serviceContext, config);
         server.setHandler(handler);
         server.setErrorHandler(new HttpErrorHandler());
@@ -72,6 +72,22 @@ public class HttpEndpoint implements Endpoint<HttpEndpointConfig> {
         catch (Exception e) {
             throw new EndpointException("error starting HTTP endpoint", e);
         }
+    }
+
+
+    /**
+     * Hide sever (Jetty) information in the http response header.
+     */
+    public void configHttpResponseHeader() {
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        httpConfig.setSendServerVersion(false);
+        httpConfig.setSendDateHeader(false);
+        httpConfig.setSendXPoweredBy(false);
+
+        server = new Server();
+        ServerConnector serverConnector = new ServerConnector(server, new HttpConnectionFactory(httpConfig));
+        serverConnector.setPort(config.getPort());
+        server.addConnector(serverConnector);
     }
 
 


### PR DESCRIPTION
## Description and context of change:
I worked on the http response header infos. In terms of security (Vulnarabilities) some of the infos aren't supposed to be shown necessarily in the response, And this issue has been fixed and yet to be extended/updated.