### PR TITLE
Changed separator for env. variables from '.' to '_'

### DIFF
--- a/misc/docker/docker-compose.yml
+++ b/misc/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     volumes:
       - ../examples/:/app/resources/
     environment:
-      - faaast.model=/app/resources/demoAAS.json
-      - faaast.config=/app/resources/exampleConfiguration.json
+      - faaast_model=/app/resources/demoAAS.json
+      - faaast_config=/app/resources/exampleConfiguration.json
     ports:
       - 8080:8080


### PR DESCRIPTION
For the docker-compose to work as expected/ described by the documentation, the separator for the environment variables defined in the docker-compose.yml has to be changed from dot to underscore.