### PR TITLE
Update HTTP API to v3 - rename /submodels to /submodel-refs in AAS API

### DIFF
--- a/docs/source/endpoints/http_endpoint.md
+++ b/docs/source/endpoints/http_endpoint.md
@@ -49,8 +49,8 @@ In order to use the HTTP Endpoint the configuration settings require to include 
     -   /shells/{aasIdentifier}/aas ![GET](https://img.shields.io/badge/GET-blue) ![PUT](https://img.shields.io/badge/PUT-orange)
     -   /shells/{aasIdentifier}/aas/asset-information ![GET](https://img.shields.io/badge/GET-blue) ![PUT](https://img.shields.io/badge/PUT-orange)
     -   /shells/{aasIdentifier}/aas/asset-information/thumbnail ![GET](https://img.shields.io/badge/GET-blue) ![PUT](https://img.shields.io/badge/PUT-orange) ![DELETE](https://img.shields.io/badge/DELETE-red)
-    -   /shells/{aasIdentifier}/aas/submodels ![GET](https://img.shields.io/badge/GET-blue) ![POST](https://img.shields.io/badge/POST-brightgreen)
-    -   /shells/{aasIdentifier}/aas/submodels/{submodelIdentifier} ![DELETE](https://img.shields.io/badge/DELETE-red)
+    -   /shells/{aasIdentifier}/aas/submodel-refs ![GET](https://img.shields.io/badge/GET-blue) ![POST](https://img.shields.io/badge/POST-brightgreen)
+    -   /shells/{aasIdentifier}/aas/submodel-refs/{submodelIdentifier} ![DELETE](https://img.shields.io/badge/DELETE-red)
 
 -   Submodel Repository Interface
     -   /submodels ![GET](https://img.shields.io/badge/GET-blue) ![POST](https://img.shields.io/badge/POST-brightgreen)

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/aas/DeleteSubmodelReferenceRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/aas/DeleteSubmodelReferenceRequestMapper.java
@@ -27,13 +27,13 @@ import java.util.Map;
 
 
 /**
- * class to map HTTP-DELETE-Request path: shells/{aasIdentifier}/aas/submodels/{submodelIdentifier}.
+ * class to map HTTP-DELETE-Request path: shells/{aasIdentifier}/aas/submodel-refs/{submodelIdentifier}.
  */
 public class DeleteSubmodelReferenceRequestMapper extends AbstractRequestMapper {
 
     private static final String AAS_ID = RegExHelper.uniqueGroupName();
     private static final String SUBMODEL_ID = RegExHelper.uniqueGroupName();
-    private static final String PATTERN = String.format("shells/%s/aas/submodels/%s",
+    private static final String PATTERN = String.format("shells/%s/aas/submodel-refs/%s",
             pathElement(AAS_ID),
             pathElement(SUBMODEL_ID));
 

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/aas/GetAllSubmodelReferencesRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/aas/GetAllSubmodelReferencesRequestMapper.java
@@ -27,12 +27,12 @@ import java.util.Map;
 
 
 /**
- * class to map HTTP-GET-Request path: /shells/{aasIdentifier}/aas/submodels.
+ * class to map HTTP-GET-Request path: /shells/{aasIdentifier}/aas/submodel-refs.
  */
 public class GetAllSubmodelReferencesRequestMapper extends AbstractRequestMapperWithOutputModifier<GetAllSubmodelReferencesRequest, GetAllSubmodelReferencesResponse> {
 
     private static final String AAS_ID = RegExHelper.uniqueGroupName();
-    private static final String PATTERN = String.format("shells/%s/aas/submodels", pathElement(AAS_ID));
+    private static final String PATTERN = String.format("shells/%s/aas/submodel-refs", pathElement(AAS_ID));
 
     public GetAllSubmodelReferencesRequestMapper(ServiceContext serviceContext) {
         super(serviceContext, HttpMethod.GET, PATTERN);

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/aas/PostSubmodelReferenceRequestMapper.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/mapper/aas/PostSubmodelReferenceRequestMapper.java
@@ -28,12 +28,12 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 
 
 /**
- * class to map HTTP-POST-Request path: /shells/{aasIdentifier}/aas/submodels.
+ * class to map HTTP-POST-Request path: /shells/{aasIdentifier}/aas/submodel-refs.
  */
 public class PostSubmodelReferenceRequestMapper extends AbstractRequestMapper {
 
     private static final String AAS_ID = RegExHelper.uniqueGroupName();
-    private static final String PATTERN = String.format("shells/%s/aas/submodels", pathElement(AAS_ID));
+    private static final String PATTERN = String.format("shells/%s/aas/submodel-refs", pathElement(AAS_ID));
 
     public PostSubmodelReferenceRequestMapper(ServiceContext serviceContext) {
         super(serviceContext, HttpMethod.POST, PATTERN);

--- a/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
+++ b/endpoint/http/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/request/RequestMappingManagerTest.java
@@ -263,7 +263,7 @@ public class RequestMappingManagerTest {
                 .build();
         Request actual = mappingManager.map(HttpRequest.builder()
                 .method(HttpMethod.DELETE)
-                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getId()) + "/aas/submodels/"
+                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getId()) + "/aas/submodel-refs/"
                         + EncodingHelper.base64UrlEncode(SUBMODEL.getId()))
                 .build());
         Assert.assertEquals(expected, actual);
@@ -497,7 +497,7 @@ public class RequestMappingManagerTest {
                 .build();
         Request actual = mappingManager.map(HttpRequest.builder()
                 .method(HttpMethod.GET)
-                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getId()) + "/aas/submodels")
+                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getId()) + "/aas/submodel-refs")
                 .build());
         Assert.assertEquals(expected, actual);
     }
@@ -1067,7 +1067,7 @@ public class RequestMappingManagerTest {
                 .build();
         Request actual = mappingManager.map(HttpRequest.builder()
                 .method(HttpMethod.POST)
-                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getId()) + "/aas/submodels")
+                .path("shells/" + EncodingHelper.base64UrlEncode(AAS.getId()) + "/aas/submodel-refs")
                 .body(serializer.write(submodelRef).getBytes())
                 .build());
         Assert.assertEquals(expected, actual);

--- a/test/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/test/HttpEndpointIT.java
+++ b/test/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/test/HttpEndpointIT.java
@@ -743,7 +743,7 @@ public class HttpEndpointIT extends AbstractIntegrationTest {
                 LambdaExceptionHelper.wrap(
                         x -> assertExecute(
                                 HttpMethod.DELETE,
-                                apiPaths.aasInterface(aas).submodel(submodelToDelete),
+                                apiPaths.aasInterface(aas).submodelRefs(submodelToDelete),
                                 StatusCode.SUCCESS_NO_CONTENT)));
         List<Reference> actual = HttpHelper.getWithMultipleResult(
                 httpClient,

--- a/test/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/test/util/ApiPaths.java
+++ b/test/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/test/util/ApiPaths.java
@@ -331,7 +331,7 @@ public class ApiPaths {
 
 
         public String submodels() {
-            return String.format("%s/submodels", assetAdministrationShell());
+            return String.format("%s/submodel-refs", assetAdministrationShell());
         }
 
 
@@ -347,6 +347,12 @@ public class ApiPaths {
 
         public String submodel(Reference reference) {
             return submodel(reference.getKeys().get(0).getValue());
+        }
+
+        public String submodelRefs(Reference reference) {
+            return String.format("%s/submodel-refs/%s",
+                    assetAdministrationShell(),
+                    EncodingHelper.base64UrlEncode(reference.getKeys().get(0).getValue()));
         }
 
 


### PR DESCRIPTION
renamed the old /shells/{aasIdentifier}/aas/submodels **requestMappers** to /shells/{aasIdentifier}/aas/submodel-refs (/aas/submodels does not exist in SwaggerHub)