### PR TITLE
Bump io.github.git-commit-id:git-commit-id-maven-plugin from 7.0.0 to 8.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <maven.plugin.compiler.version>3.12.1</maven.plugin.compiler.version>
         <maven.plugin.dependency.version>3.6.1</maven.plugin.dependency.version>
         <maven.plugin.failsafe.version>3.2.5</maven.plugin.failsafe.version>
-        <maven.plugin.git.commit.id.version>7.0.0</maven.plugin.git.commit.id.version>
+        <maven.plugin.git.commit.id.version>8.0.0</maven.plugin.git.commit.id.version>
         <maven.plugin.gpg.version>3.1.0</maven.plugin.gpg.version>
         <maven.plugin.jacoco.version>0.8.11</maven.plugin.jacoco.version>
         <maven.plugin.jar.version>3.3.0</maven.plugin.jar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <maven.plugin.compiler.version>3.12.1</maven.plugin.compiler.version>
         <maven.plugin.dependency.version>3.6.1</maven.plugin.dependency.version>
         <maven.plugin.failsafe.version>3.2.5</maven.plugin.failsafe.version>
-        <maven.plugin.git.commit.id.version>8.0.0</maven.plugin.git.commit.id.version>
+        <maven.plugin.git.commit.id.version>8.0.1</maven.plugin.git.commit.id.version>
         <maven.plugin.gpg.version>3.1.0</maven.plugin.gpg.version>
         <maven.plugin.jacoco.version>0.8.11</maven.plugin.jacoco.version>
         <maven.plugin.jar.version>3.3.0</maven.plugin.jar.version>


### PR DESCRIPTION
Waiting for unexpected breaking changes after major update to be addressed, see https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/712