### PR TITLE
filter files according to AASX / JSON file extensions

### DIFF
--- a/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/App.java
+++ b/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/App.java
@@ -394,7 +394,8 @@ public class App implements Runnable {
                             .getName()
                             .matches(MODEL_FILENAME_PATTERN))
                     .map(Path::toFile)) {
-                modelFiles = stream.filter(f -> fileExtensions.stream().anyMatch(f.getName()::endsWith))
+                modelFiles = stream.filter(f -> fileExtensions.stream()
+                        .anyMatch(FileHelper.getFileExtensionWithoutSeparator(f.getName())::equalsIgnoreCase))
                         .collect(Collectors.toList());
             }
             if (modelFiles.size() > 1 && LOGGER.isWarnEnabled()) {

--- a/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/App.java
+++ b/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/App.java
@@ -387,12 +387,15 @@ public class App implements Runnable {
     private Optional<File> findDefaultModel() {
         try {
             List<File> modelFiles;
+            List<String> fileExtensions = new ArrayList<>(DataFormat.AASX.getFileExtensions());
+            fileExtensions.addAll(DataFormat.JSON.getFileExtensions());
             try (Stream<File> stream = Files.find(Paths.get(""), 1,
                     (file, attributes) -> file.toFile()
                             .getName()
                             .matches(MODEL_FILENAME_PATTERN))
                     .map(Path::toFile)) {
-                modelFiles = stream.collect(Collectors.toList());
+                modelFiles = stream.filter(f -> fileExtensions.stream().anyMatch(f.getName()::endsWith))
+                        .collect(Collectors.toList());
             }
             if (modelFiles.size() > 1 && LOGGER.isWarnEnabled()) {
                 LOGGER.warn("Found multiple model files matching the default pattern. To use a specific one use command '{} <filename>' (files found: {}, file pattern: {})",

--- a/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/App.java
+++ b/starter/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/starter/App.java
@@ -396,7 +396,7 @@ public class App implements Runnable {
                     .map(Path::toFile)) {
                 modelFiles = stream.filter(f -> fileExtensions.stream()
                         .anyMatch(FileHelper.getFileExtensionWithoutSeparator(f.getName())::equalsIgnoreCase))
-                        .collect(Collectors.toList());
+                        .toList();
             }
             if (modelFiles.size() > 1 && LOGGER.isWarnEnabled()) {
                 LOGGER.warn("Found multiple model files matching the default pattern. To use a specific one use command '{} <filename>' (files found: {}, file pattern: {})",


### PR DESCRIPTION
This should prevent matching default files with names not ending on .aasx or .json (like .aasxORIGINAL)