### PR TITLE
[Bugfix] Change serialization of "_interface" to "interface"

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/EndpointMixin.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/EndpointMixin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.service.registry;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
+
+
+/**
+ * Mixin for {@link org.eclipse.digitaltwin.aas4j.v3.model.Endpoint}.
+ */
+public interface EndpointMixin {
+    @JsonProperty("interface")
+    public Endpoint get_interface();
+}

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/EndpointMixin.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/EndpointMixin.java
@@ -24,7 +24,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
 public interface EndpointMixin {
     /**
      * Changes "_interface" to "interface".
-     * 
+     *
      * @return "interface"
      */
     @JsonProperty("interface")

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/EndpointMixin.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/EndpointMixin.java
@@ -22,6 +22,11 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
  * Mixin for {@link org.eclipse.digitaltwin.aas4j.v3.model.Endpoint}.
  */
 public interface EndpointMixin {
+    /**
+     * Changes "_interface" to "interface".
+     * 
+     * @return "interface"
+     */
     @JsonProperty("interface")
     public Endpoint get_interface();
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronization.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronization.java
@@ -55,6 +55,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShellDescriptor;
+import org.eclipse.digitaltwin.aas4j.v3.model.Endpoint;
 import org.eclipse.digitaltwin.aas4j.v3.model.Key;
 import org.eclipse.digitaltwin.aas4j.v3.model.KeyTypes;
 import org.eclipse.digitaltwin.aas4j.v3.model.SecurityAttributeObject;
@@ -93,7 +94,8 @@ public class RegistrySynchronization {
             .enable(SerializationFeature.INDENT_OUTPUT)
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
-            .addMixIn(SecurityAttributeObject.class, SecurityAttributeObjectMixin.class);
+            .addMixIn(SecurityAttributeObject.class, SecurityAttributeObjectMixin.class)
+            .addMixIn(Endpoint.class, EndpointMixin.class);
     private ExecutorService executor;
     private boolean running = false;
 

--- a/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronizationTest.java
+++ b/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/service/registry/RegistrySynchronizationTest.java
@@ -92,7 +92,8 @@ public class RegistrySynchronizationTest {
                 .enable(SerializationFeature.INDENT_OUTPUT)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .setSerializationInclusion(JsonInclude.Include.NON_EMPTY)
-                .addMixIn(SecurityAttributeObject.class, SecurityAttributeObjectMixin.class);
+                .addMixIn(SecurityAttributeObject.class, SecurityAttributeObjectMixin.class)
+                .addMixIn(org.eclipse.digitaltwin.aas4j.v3.model.Endpoint.class, EndpointMixin.class);
         mockEndpoint();
         mockMessageBus();
         mockPersistence();

--- a/docs/source/other/release-notes.md
+++ b/docs/source/other/release-notes.md
@@ -12,6 +12,7 @@
 	- Model validation no longer throws an error if a model contains multiple instances of exactly the same Identifiable. This is not 100% correct behavior according to the specification as it validates the uniqueness criteria of their ID, however, it helps tremendously when working with existing SMTs as many of them are currently also not 100% standard-compliant and contain such duplicate elements.
 	- Fixed bug when executing an operation asynchronously. When the timeout has expired, the status of the operation was set to timeout, even if the operation  already finished successfully. This does no longer happen - the timeout no longer overwrites the result of the operation.
 	- Fix warning message about missing Log4j2 logging implementation
+	- Fix registry synchronization because of invalid _interface serialization
 - Endpoint
 	- HTTP
 		- Fixed query modifier `extent` which has not been working as intended


### PR DESCRIPTION
The Jackson Mapper serialized interface in DefaultEndpoint with "_interface" leading to failures in registration