### PR TITLE
Small bugfixes in HTTP endpoint

### DIFF
--- a/docs/source/other/release-notes.md
+++ b/docs/source/other/release-notes.md
@@ -1,6 +1,13 @@
 # Release Notes
 <!--start:changelog-header-->
 ## 1.3.0-SNAPSHOT (current development version)<!--end:changelog-header-->
+
+**Internal changes & bugfixes**
+- Endpoint
+	- HTTP
+		- URL query parameters are now correctly URL-decoded
+		- Enabled `level` query parameter for calls to /submodels/{submodelIdentifier}/$reference as this is not explicitely forbidden in the specification although the parameter does not have any actual effect
+
 ## 1.2.0
 
 **New Features & Major Changes**

--- a/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/model/HttpRequest.java
+++ b/endpoint/http/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/endpoint/http/model/HttpRequest.java
@@ -15,6 +15,7 @@
 package de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.model;
 
 import de.fraunhofer.iosb.ilt.faaast.service.endpoint.http.util.HttpConstants;
+import de.fraunhofer.iosb.ilt.faaast.service.util.EncodingHelper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -170,9 +171,10 @@ public class HttpRequest extends HttpMessage {
     public void setQueryParametersFromQueryString(String queryString) {
         this.queryParameters = queryString != null && queryString.contains("=")
                 ? Arrays.asList(queryString.split("&")).stream()
-                        .map(x -> splitKeyValue(x, "=")).collect(Collectors.toMap(
+                        .map(x -> splitKeyValue(x, "="))
+                        .collect(Collectors.toMap(
                                 x -> x[0],
-                                x -> x[1],
+                                x -> EncodingHelper.urlDecode(x[1]),
                                 (oldValue, newValue) -> newValue))
                 : new HashMap<>();
     }

--- a/model/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/model/api/request/submodel/GetAllSubmodelElementsReferenceRequest.java
+++ b/model/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/model/api/request/submodel/GetAllSubmodelElementsReferenceRequest.java
@@ -31,7 +31,7 @@ public class GetAllSubmodelElementsReferenceRequest extends AbstractSubmodelInte
         super(OutputModifierConstraints.builder()
                 .supportedContentModifiers(Content.REFERENCE)
                 .supportsExtent(false)
-                .supportsLevel(false)
+                .supportsLevel(true)
                 .build());
     }
 


### PR DESCRIPTION
* URL query parameters are now correctly URL-decoded
* Enabled `level` query parameter for calls to /submodels/{submodelIdentifier}/$reference as this is not explicitely forbidden in the specification although the parameter does not have any actual effect