### PR TITLE
[Documentation] mount directly into /app/model.json, add contentType to /import

### DIFF
--- a/docs/source/basics/usage.md
+++ b/docs/source/basics/usage.md
@@ -55,10 +55,11 @@ To run FA³ST Service via docker with an empty model and default configuration e
 > docker run fraunhoferiosb/faaast-service
 ```
 
-To make you of the full power of docker and FA³ST Service, you can also mount files to the container and pass arguments via CLI or environment variables like this
+To make you of the full power of docker and FA³ST Service, you can also mount files to the container and pass arguments via CLI or environment variables like this.
+If the model is not loaded, validation can be turned off by attaching '--no-validation'.
 
 ```sh
-> docker run -v {path to your model file}:/model.json -e faaast.model=model.json fraunhoferiosb/faaast-service '--no-validation'
+> docker run -v {path to your model file}:/app/model.json fraunhoferiosb/faaast-service
 ```
 
 FA³ST Service also comes with a docker compose file located at `/misc/docker/docker-compose.yml` which can be executed by navigation to the directory `/misc/docker` and execute `docker-compose up`.

--- a/docs/source/interfaces/endpoint.md
+++ b/docs/source/interfaces/endpoint.md
@@ -109,10 +109,10 @@ FA³ST Service supports the following APIs as defined by the [OpenAPI documentat
 
 Additionally, FA³ST Service offers the following proprietary API calls:
 
-| HTTP Method | URL Path | Description                                                                                                                             | Payload             | Response                                                                 |
-| ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------ |
-| GET         | /reset   | Resets the server which includes deleting all AASs, submodels, concept descriptions, files, asset connections, and pending operations.  | -                   | `204 No Content`                                                         |
-| POST        | /import  | Imports an AAS files in any supported data format. Set the `Content-Type` header accordingly so that the server can parse the document. | The file to upload. | `200 Ok` with body containing list of errors that happend during import. |
+| HTTP Method | URL Path | Description                                                                                                                                                                                                 | Payload             | Response                                                                 |
+| ----------- | -------- |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ------------------- | ------------------------------------------------------------------------ |
+| GET         | /reset   | Resets the server which includes deleting all AASs, submodels, concept descriptions, files, asset connections, and pending operations.                                                                      | -                   | `204 No Content`                                                         |
+| POST        | /import  | Imports an AAS files in any supported data format. Set the `Content-Type` header accordingly so that the server can parse the document. For AASX, it is application/asset-administration-shell-package+xml. | The file to upload. | `200 Ok` with body containing list of errors that happend during import. |
 
 
 #### Using HTTP PATCH


### PR DESCRIPTION
Some small adjustments to documentation based on first user-feedback having trouble