### PR TITLE
fix(docs): EventMessage wrong indentation

### DIFF
--- a/docs/source/interfaces/message-bus.md
+++ b/docs/source/interfaces/message-bus.md
@@ -24,7 +24,7 @@ This is the class hierarchy of available event classes/types
 			- `ElementCreateEventMessage`:			Triggered when an element is created
 			- `ElementDeleteEventMessage`:			Triggered when an element is deleted
 			- `ElementUpdateEventMessage`:			Triggered when an element is updated
-			- `ValueChangeEventMessage`:			Triggered when the value of an element is updated, payload: old value, new value
+		- `ValueChangeEventMessage`:			Triggered when the value of an element is updated, payload: old value, new value
 	- `ErrorEventMessage`:							Triggered when an error occurred, payload: message, error level (INFO, WARN, ERROR)
 
 


### PR DESCRIPTION
ValueChangeEventMessage inherits directly from ChangeEventMessage and not from ElementChangeEventMessage (see https://github.com/FraunhoferIOSB/FAAAST-Service/blob/main/model/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/model/messagebus/event/change/ValueChangeEventMessage.java).

This might be confusing when reading the doc.