### PR TITLE
fix: order of imported elements

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/proprietary/ImportRequestHandler.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/request/handler/proprietary/ImportRequestHandler.java
@@ -57,8 +57,8 @@ public class ImportRequestHandler extends AbstractRequestHandler<ImportRequest, 
                 .read(new ByteArrayInputStream(request.getContent()));
         ImportResult.Builder result = ImportResult.builder();
         StreamHelper.concat(
-                environmentContext.getEnvironment().getAssetAdministrationShells().stream(),
                 environmentContext.getEnvironment().getSubmodels().stream(),
+                environmentContext.getEnvironment().getAssetAdministrationShells().stream(),
                 environmentContext.getEnvironment().getConceptDescriptions().stream())
                 .forEach(x -> {
                     try {


### PR DESCRIPTION
/import first stores AAS, then submodels.

The ElementCreatedEvents are triggered for the AAS which refer to non-existent Submodels. The resulting shellDescriptors from RegistrySynchronization have empty submodel fields...
