### PR TITLE
fix: MessageBus CloudEvents QOL

### DIFF
--- a/docs/source/interfaces/message-bus.md
+++ b/docs/source/interfaces/message-bus.md
@@ -170,16 +170,18 @@ This implementation of the `MessageBus` interface publishes CloudEvent messages 
 
 ### Topics & Payload
 
-Each message type is published on its own topic in the form of `[topicPrefix]`.
-The payload is a JSON serialization of a CloudEvent as specified in the async-aas specification: https://factory-x-contributions.github.io/async-aas-helm
+Each message is published under the topic defined in `[topicPrefix]`.
+The payload is a JSON serialization of a CloudEvent as specified in the async-aas specification: [https://factory-x-contributions.github.io/async-aas-helm](https://factory-x-contributions.github.io/async-aas-helm)
+
+Note: To modify the URL in a CloudEvent's `source` field, the configuration `core.callbackAddress` needs to be added. Else, `localhost` will be used.
 
 ### Configuration
 
-:::{table} Configuration properties of MQTT MessageBus.
+:::{table} Configuration properties of CloudEvents MessageBus.
 | Name                                | Allowed Value                                               | Description                                                                                                                                                     | Default Value                                                                                        |
 | ----------------------------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | host<br>                            | String                                                      | The host name of the MQTT server with scheme, port and path segments if relevant.                                                                               |                                                                                                      |
-| clientId<br>*(optional)*            | String                                                      | ClientId to use when connecting to the MQTT server. This clientId will only be used to identify as a MQTT publisher, not for oauth-flows or as a username.      | FA3ST MQTT MessageBus                                                                                |
+| clientId<br>*(optional)*            | String                                                      | ClientId to use when connecting to the MQTT server. This clientId will only be used to identify as a MQTT publisher, not for oauth-flows or as a username.      | A randomized identifier                                                                                |
 | username<br>*(optional)*            | String                                                      | Username used to connect to the MQTT server.                                                                                                                    |                                                                                                      |
 | password<br>*(optional)*            | String                                                      | Password used to connect to the MQTT server.                                                                                                                    |                                                                                                      |
 | identityProviderUrl<br>*(optional)* | String                                                      | Oauth2 IdP URL. Obtained tokens are placed as the MQTT broker password, the username is obtained from the username config. Token refresh happens automatically. |                                                                                                      |
@@ -197,8 +199,7 @@ The payload is a JSON serialization of a CloudEvent as specified in the async-aa
 :lineno-start: 1
 {
 	"messageBus": {
-		"@class": "de.fraunhofer.iosb.ilt.faaast.service.messagebus.mqtt.MessageBusMqtt",
-		"useInternalServer": true,
+		"@class": "de.fraunhofer.iosb.ilt.faaast.service.messagebus.cloudevents.MessageBusCloudEvents",
 		"host": "tcp://localhost:1883",
 		"clientCertificate": {
 			"keyStoreType": "PKCS12",

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudEvents.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/MessageBusCloudEvents.java
@@ -41,6 +41,7 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.messagebus.SubscriptionInfo;
 import de.fraunhofer.iosb.ilt.faaast.service.util.EnvironmentHelper;
 import io.cloudevents.CloudEvent;
 import io.cloudevents.jackson.JsonFormat;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory;
 public class MessageBusCloudEvents implements MessageBus<MessageBusCloudEventsConfig> {
 
     private static final String PUBLISH_ERROR_MSG = "{} publishing event via CloudEvents MQTT message bus for message type {}";
+    private static final String DEFAULT_CALLBACK_ADDRESS = "localhost";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageBusCloudEvents.class);
 
@@ -140,7 +142,13 @@ public class MessageBusCloudEvents implements MessageBus<MessageBusCloudEventsCo
             }
         };
 
-        mapperRegistry = defaultRegistry(CloudEventMapperConfig.from(config, coreConfig.getCallbackAddress()), referableSupplier);
+        String callbackAddress = Optional.ofNullable(coreConfig.getCallbackAddress())
+                .orElseGet(() -> {
+                    LOGGER.warn("No callbackAddress configured in the core configuration. Using '{}' as CloudEvent 'source' URL", DEFAULT_CALLBACK_ADDRESS);
+                    return DEFAULT_CALLBACK_ADDRESS;
+                });
+
+        mapperRegistry = defaultRegistry(CloudEventMapperConfig.from(config, callbackAddress), referableSupplier);
     }
 
 

--- a/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/mqtt/client/config/MqttClientConfig.java
+++ b/messagebus/cloudevents/src/main/java/de/fraunhofer/iosb/ilt/faaast/service/messagebus/cloudevents/mqtt/client/config/MqttClientConfig.java
@@ -16,7 +16,7 @@ package de.fraunhofer.iosb.ilt.faaast.service.messagebus.cloudevents.mqtt.client
 
 import de.fraunhofer.iosb.ilt.faaast.service.config.CertificateConfig;
 import de.fraunhofer.iosb.ilt.faaast.service.messagebus.cloudevents.MessageBusCloudEventsConfig;
-import java.util.Objects;
+import de.fraunhofer.iosb.ilt.faaast.service.util.Ensure;
 
 
 /**
@@ -43,7 +43,7 @@ public record MqttClientConfig(
      * Record constructor.
      */
     public MqttClientConfig {
-        Objects.requireNonNull(host);
+        Ensure.requireNonNull(host, "CloudEvents MQTT broker host cannot be empty.");
     }
 
 


### PR DESCRIPTION
- Default value for the URL inside the `source` field of a CloudEvent
- Updated documentation (e.g., wrong `@class` in the example config)
- Error message for missing required field
