### PR TITLE
fix: support argocd vault plugin

### DIFF
--- a/.github/workflows/helm-build.yml
+++ b/.github/workflows/helm-build.yml
@@ -9,10 +9,6 @@ on:
       - charts
     tags:
       - "v*"
-  pull_request:
-    # If PR and charts/** was modified, release snapshot
-    paths:
-      - 'charts/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/helm-build.yml
+++ b/.github/workflows/helm-build.yml
@@ -9,6 +9,10 @@ on:
       - charts
     tags:
       - "v*"
+  pull_request:
+    # If PR and charts/** was modified, release snapshot
+    paths:
+      - "charts"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/helm-build.yml
+++ b/.github/workflows/helm-build.yml
@@ -12,7 +12,7 @@ on:
   pull_request:
     # If PR and charts/** was modified, release snapshot
     paths:
-      - "charts"
+      - 'charts/**'
   workflow_dispatch:
 
 jobs:

--- a/charts/faaast-service/Chart.yaml
+++ b/charts/faaast-service/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/faaast-service/templates/configmap.yaml
+++ b/charts/faaast-service/templates/configmap.yaml
@@ -20,23 +20,23 @@ data:
   config.json: |
     {
       {{- with .Values.core }}
-      "core": {{ toPrettyJson . | nindent 6 | trim }},
+      "core": {{ toJson . | nindent 6 | trim }},
       {{- end }}
 
       {{- with .Values.endpoints }}
-      "endpoints": {{ toPrettyJson $endpoints | nindent 6 | trim }},
+      "endpoints": {{ toJson $endpoints | nindent 6 | trim }},
       {{- end }}
 
       {{- with .Values.assetConnections }}
-      "assetConnections": {{ toPrettyJson . | nindent 6 | trim }},
+      "assetConnections": {{ toJson . | nindent 6 | trim }},
       {{- end }}
 
       {{- with .Values.submodelTemplateProcessors }}
-      "submodelTemplateProcessors": {{ toPrettyJson . | nindent 6 | trim }}
+      "submodelTemplateProcessors": {{ toJson . | nindent 6 | trim }}
       {{- end }}
 
       {{- if hasKey .Values "persistence" }}
-      "persistence": {{ toPrettyJson .Values.persistence | nindent 6 | trim }},
+      "persistence": {{ toJson .Values.persistence | nindent 6 | trim }},
       {{- else }}
       "persistence": {
         "@class": "de.fraunhofer.iosb.ilt.faaast.service.persistence.memory.PersistenceInMemory"
@@ -44,7 +44,7 @@ data:
       {{- end }}
 
       {{- if hasKey .Values "messageBus" }}
-      "messageBus": {{ toPrettyJson .Values.messageBus | nindent 6 | trim }}
+      "messageBus": {{ toJson .Values.messageBus | nindent 6 | trim }}
       {{- else }}
       "messageBus": {
         "@class": "de.fraunhofer.iosb.ilt.faaast.service.messagebus.internal.MessageBusInternal"

--- a/charts/faaast-service/templates/configmap.yaml
+++ b/charts/faaast-service/templates/configmap.yaml
@@ -20,23 +20,23 @@ data:
   config.json: |
     {
       {{- with .Values.core }}
-      "core": {{ toJson . | nindent 6 | trim }},
+      "core": {{ toRawJson . | nindent 6 | trim }},
       {{- end }}
 
       {{- with .Values.endpoints }}
-      "endpoints": {{ toJson $endpoints | nindent 6 | trim }},
+      "endpoints": {{ toRawJson $endpoints | nindent 6 | trim }},
       {{- end }}
 
       {{- with .Values.assetConnections }}
-      "assetConnections": {{ toJson . | nindent 6 | trim }},
+      "assetConnections": {{ toRawJson . | nindent 6 | trim }},
       {{- end }}
 
       {{- with .Values.submodelTemplateProcessors }}
-      "submodelTemplateProcessors": {{ toJson . | nindent 6 | trim }}
+      "submodelTemplateProcessors": {{ toRawJson . | nindent 6 | trim }}
       {{- end }}
 
       {{- if hasKey .Values "persistence" }}
-      "persistence": {{ toJson .Values.persistence | nindent 6 | trim }},
+      "persistence": {{ toRawJson .Values.persistence | nindent 6 | trim }},
       {{- else }}
       "persistence": {
         "@class": "de.fraunhofer.iosb.ilt.faaast.service.persistence.memory.PersistenceInMemory"
@@ -44,7 +44,7 @@ data:
       {{- end }}
 
       {{- if hasKey .Values "messageBus" }}
-      "messageBus": {{ toJson .Values.messageBus | nindent 6 | trim }}
+      "messageBus": {{ toRawJson .Values.messageBus | nindent 6 | trim }}
       {{- else }}
       "messageBus": {
         "@class": "de.fraunhofer.iosb.ilt.faaast.service.messagebus.internal.MessageBusInternal"

--- a/charts/faaast-service/templates/deployment.yaml
+++ b/charts/faaast-service/templates/deployment.yaml
@@ -63,13 +63,15 @@ spec:
       {{- if and (hasKey .Values "messageBus") (eq (index .Values.messageBus "@class") "de.fraunhofer.iosb.ilt.faaast.service.messagebus.cloudevents.MessageBusCloudevents") }}
         - name: wait-for-cloudevents-mqtt
           image: busybox:1.35
-          {{- $hp := splitList ":" .Values.messageBus.host }}
           command:
             - sh
             - -c
             - |
               echo "Waiting for CloudEvents MQTT broker to be ready..."
-              until nc -z {{ index $hp 1 | trimPrefix "//" }} {{ index $hp 2 }}; do
+              URL="{{ .Values.messageBus.host }}"
+              HOST=$(echo "$URL" | sed -E 's,^[a-zA-Z]+://([^:/]+).*,\1,')
+              PORT=$(echo "$URL" | sed -E 's,.*:([0-9]+)$,\1,')
+              until nc -z "$HOST" "$PORT"; do
                 echo "CloudEvents MQTT broker not ready, waiting..."
                 sleep 5
               done
@@ -83,7 +85,7 @@ spec:
             - -c
             - |
               echo "Waiting for MQTT broker to be ready..."
-              until nc -z {{ .Values.messageBus.host }} .{{ .Values.messageBus.port }}; do
+              until nc -z {{ .Values.messageBus.host }} {{ .Values.messageBus.port }}; do
                 echo "MQTT broker not ready, waiting..."
                 sleep 5
               done


### PR DESCRIPTION
ArgoCD Vault Plugin allows to define paths to vault secrets in deployment configurations. These paths are resolved after `helm template` is executed. The current chart `deployment.yaml` does not allow this to work, modifying the path reference before it can be resolved by the plugin.